### PR TITLE
Feature/incremental build

### DIFF
--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -127,7 +127,7 @@
   <!--
     Performs the actual compilation of the input files (*.sql) into a .dacpac package by calling into a command line tool to do the actual work.
   -->
-  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabasePackageReferences" Inputs="@(Content)" Outputs="$(TargetPath)">
+  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabasePackageReferences" Inputs="@(Content);$(ProjectPath)" Outputs="$(TargetPath)">
     <ItemGroup>
       <_PropertyNames Include="$(KnownModelProperties)" />
       <PropertyNames Include="@(_PropertyNames)" Condition=" '$(%(Identity))' != '' ">

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -33,7 +33,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetPath>$(TargetDir)/$(MSBuildProjectName).dacpac</TargetPath>
+    <TargetExt>.dacpac</TargetExt>
+    <TargetPath>$(TargetDir)/$(MSBuildProjectName)$(TargetExt)</TargetPath>
     <CoreBuildDependsOn>
       BuildOnlySettings;
       PrepareForBuild;

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -127,7 +127,7 @@
   <!--
     Performs the actual compilation of the input files (*.sql) into a .dacpac package by calling into a command line tool to do the actual work.
   -->
-  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabasePackageReferences">
+  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabasePackageReferences" Inputs="@(Content)" Outputs="$(TargetPath)">
     <ItemGroup>
       <_PropertyNames Include="$(KnownModelProperties)" />
       <PropertyNames Include="@(_PropertyNames)" Condition=" '$(%(Identity))' != '' ">


### PR DESCRIPTION
This should solve the incremental build support issue (#34). 
It also corrects the extension of the output (from default .dll -> .dacpac).
If you run build on project using this sdk twice, the second time it won't execute the **CoreCompile** target unless the content (the SQL files) or the project itself (e.g. build properties) was changed.

However the Visual Studio still detects this as if the build is needed. In the end this is quite fine as this won't take much time (on my computer about 1s to complete the Build target without CoreCompile).

I have also tried to include and skip Build target (like from C:\Program Files\dotnet\sdk\3.1.301\Microsoft.Common.CurrentVersion.targets) but the VS still marks the whole project as "need build" so this won't solve it either.

In the end just this simple edit (adding Inputs/Outputs) save the day for me.

PS: I do have also "ScaffoldDatabase" target in my Sql.Build project, that will execute a script to scaffold built **dacpac** file to C# classes. I needed to implement a timestamp check not to scaffold the dacpac if it was not changed.
PPS: Target CopyFilesToOutputDirectory is executed all the time. If this an issue, I can replace the "PrepareForRun" to check for inputs/outputs as well..