### PR TITLE
Add a template pack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,23 @@ jobs:
         name: nuget-packages
         path: ./test/TestProject/bin/Release/
 
+    # Replace tokens 
+    - uses: cschleiden/replace-tokens@v1
+      name: replace tokens
+      with:
+        files: 'src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.Templates.csproj'
+
+    # Package templates
+    - name: dotnet pack templates
+      run: dotnet pack -c Release src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.csproj
+
+    # Upload templates package
+    - name: upload templates
+      uses: actions/upload-artifact@v1
+      with:
+        name: nuget-packages
+        path: ./src/MSBuild.Sdk.SqlProj.Templates/bin/Release/
+
   # Run tests in parallel
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
 
     # Package templates
     - name: dotnet pack templates
-      run: dotnet pack -c Release src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.csproj
+      run: dotnet pack -c Release src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.Templates.csproj
 
     # Upload templates package
     - name: upload templates

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
     - uses: cschleiden/replace-tokens@v1
       name: replace tokens
       with:
-        files: 'src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.Templates.csproj'
+        files: 'src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/sqlproj.csproj'
 
     # Package templates
     - name: dotnet pack templates

--- a/README.md
+++ b/README.md
@@ -13,17 +13,46 @@ An MSBuild SDK that is capable of producing a SQL Server Data-Tier Application p
 Please take a moment to familiarize yourself with the [code of conduct](CODE_OF_CONDUCT.md) for this repository.
 
 ## Usage
-The simplest usage is to create a new .csproj project file with the following contents:
+The simplest way to get started is to install our templates with `dotnet new` using:
+
+```
+dotnet new install MSBuild.Sdk.SqlProj.Templates
+```
+
+You can then create a new project file using the following command. If you don't want to target the latest version of SQL Server you can specify a version to target using the `-s Sql<version>` switch. Please refer to [this document](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.model.sqlserverversion) for the available versions.
+
+```
+dotnet new sqlproj [-s Sql150]
+```
+
+You should now have a project file with the following contents:
 
 ```xml
 <Project Sdk="MSBuild.Sdk.SqlProj/1.3.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <SqlServerVersion>Sql150</SqlServerVersion>
+        <!-- For additional properties that can be set here, please refer to https://github.com/rr-wfm/MSBuild.Sdk.SqlProj#model-properties -->
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- Refer to https://github.com/rr-wfm/MSBuild.Sdk.SqlProj#publishing-support for supported publishing options -->
     </PropertyGroup>
 </Project>
 ```
 
-Then run a `dotnet build` and you'll find a .dacpac file in the `bin\Debug\netstandard2.0` folder. By default all `.sql` files will be added to the package, except for those in the `Pre-Deployment` and `Post-Deployment` folders.
+Then run a `dotnet build` and you'll find a .dacpac file in the `bin\Debug\netstandard2.0` folder. By default all `.sql` files will be added to the package, except for those in the `Pre-Deployment` and `Post-Deployment` folders. To create database objects you can use the following item templates:
+
+| Template | Command | Description |
+|+++|+++|+++|
+| table | `dotnet new table -n <name>` | Creates a new database table with the provided name |
+| view | `dotnet new view -n <name>` | Creates a new database view with the provided name |
+| sproc | `dotnet new sproc -n <name>` | Creates a new stored procedure with the provided name |
+| inlinefunc | `dotnet new inlinefunc -n <name>` | Creates a new inline function with the provided name |
+| tablefunc | `dotnet new tablefunc -n <name>` | Creates a new table-valued function with the provided name |
+| scalarfunc | `dotnet new scalarfunc -n <name>` | Creates a new scalar function with the provided name |
+
+> Note: In a future update of Visual Studio you should be able to use both the project template and the item templates directly from Visual Studio. This feature is currently in preview and some of our early testing has revealed that it doesn't work as expected. Stay tuned for updates on this.
 
 If you already have a SSDT (.sqlproj) project in your solution, you can keep that as a "companion" project in order to enjoy the Visual Studio designer experience, as described in [this blog post](https://erikej.github.io/efcore/2020/05/11/ssdt-dacpac-netcore.html).
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You should now have a project file with the following contents:
 Then run a `dotnet build` and you'll find a .dacpac file in the `bin\Debug\netstandard2.0` folder. By default all `.sql` files will be added to the package, except for those in the `Pre-Deployment` and `Post-Deployment` folders. To create database objects you can use the following item templates:
 
 | Template | Command | Description |
-|+++|+++|+++|
+| --- | --- | --- |
 | table | `dotnet new table -n <name>` | Creates a new database table with the provided name |
 | view | `dotnet new view -n <name>` | Creates a new database view with the provided name |
 | sproc | `dotnet new sproc -n <name>` | Creates a new stored procedure with the provided name |

--- a/src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.Templates.csproj
+++ b/src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.Templates.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <PackageVersion>1.0</PackageVersion>
+    <PackageId>MSBuild.Sdk.SqlProj.Templates</PackageId>
+    <Title>MSBuild.Sdk.SqlProj templates</Title>
+    <Authors>MSBuild.Sdk.SqlProj</Authors>
+    <Description>Templates that can be used to scaffold new MSBuild.Sdk.SqlProj projects.</Description>
+    <PackageTags>dotnet-new;templates;MSBuild;MSBuildSdk;sql;dacpac</PackageTags>
+
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
+    <Compile Remove="**\*" />
+  </ItemGroup>
+
+</Project>

--- a/src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.Templates.csproj
+++ b/src/MSBuild.Sdk.SqlProj.Templates/MSBuild.Sdk.SqlProj.Templates.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.0</PackageVersion>
     <PackageId>MSBuild.Sdk.SqlProj.Templates</PackageId>
     <Title>MSBuild.Sdk.SqlProj templates</Title>
     <Authors>MSBuild.Sdk.SqlProj</Authors>

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/inlinefunc/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/inlinefunc/.template.config/template.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer", "InlineFunction" ],
+    "identity": "MSBuild.Sdk.SqlProj.InlineFunction",
+    "name": "Inline function",
+    "shortName": "inlinefunc",
+    "tags": {
+      "language": "SQL",
+      "type": "item"
+    },
+    "sourceName": "Function1"
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/inlinefunc/Function1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/inlinefunc/Function1.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION [dbo].[Function1]
+(
+	@param1 int,
+	@param2 char(5)
+)
+RETURNS TABLE AS RETURN
+(
+	SELECT @param1 AS c1,
+		   @param2 AS c2
+)

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/scalarfunc/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/scalarfunc/.template.config/template.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer", "ScalarFunction" ],
+    "identity": "MSBuild.Sdk.SqlProj.ScalarFunction",
+    "name": "Scalar Function",
+    "shortName": "scalarfunc",
+    "tags": {
+      "language": "SQL",
+      "type": "item"
+    },
+    "sourceName": "Function1"
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/scalarfunc/Function1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/scalarfunc/Function1.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION [dbo].[Function1]
+(
+	@param1 int,
+	@param2 int
+)
+RETURNS INT
+AS
+BEGIN
+	RETURN @param1 + @param2
+END

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sproc/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sproc/.template.config/template.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer", "StoredProcedure" ],
+    "identity": "MSBuild.Sdk.SqlProj.StoredProcedure",
+    "name": "Stored procedure",
+    "shortName": "sproc",
+    "tags": {
+      "language": "SQL",
+      "type": "item"
+    },
+    "sourceName": "Procedure1"
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sproc/Procedure1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sproc/Procedure1.sql
@@ -1,0 +1,6 @@
+CREATE PROCEDURE [dbo].[Procedure1]
+	@param1 int = 0,
+	@param2 int
+AS
+	SELECT @param1, @param2
+RETURN 0

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/.template.config/template.json
@@ -4,6 +4,7 @@
     "classifications": [ "Database", "SqlServer" ],
     "identity": "MSBuild.Sdk.SqlProj",
     "name": "SQL Server Database Project",
+    "description": "A project that builds and publishes a SQL Server Data-Tier Application package (.dacpac)",
     "shortName": "sqlproj",
     "tags": {
       "language": "SQL",

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/.template.config/template.json
@@ -6,7 +6,7 @@
     "name": "SQL Server Database Project",
     "shortName": "sqlproj",
     "tags": {
-      "language": "C#",
+      "language": "SQL",
       "type": "project"
     },
     "sourceName": "sqlproj",

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/.template.config/template.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer" ],
+    "identity": "MSBuild.Sdk.SqlProj",
+    "name": "SQL Server Database Project",
+    "shortName": "sqlproj",
+    "tags": {
+      "language": "C#",
+      "type": "project"
+    },
+    "sourceName": "sqlproj",
+    "preferNameDirectory": true,
+    "symbols": {
+      "sqlServerVersion": {
+        "type": "parameter",
+        "defaultValue": "Sql150",
+        "replaces": "#{SqlServerVersion}",
+        "choices": [ "Sql100", "Sql110", "Sql120", "Sql130", "Sql140", "Sql150", "Sql90", "SqlAzure", "SqlDw" ],
+        "description": "Version of SQL Server being targetted"
+      }
+    }
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/sqlproj.csproj
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/sqlproj.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="MSBuild.Sdk.SqlProj/#{NBGV_NuGetPackageVersion}#">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <SqlServerVersion>#{SqlServerVersion}</SqlServerVersion>
+        <!-- For additional properties that can be set here, please refer to https://github.com/rr-wfm/MSBuild.Sdk.SqlProj#model-properties -->
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- Refer to https://github.com/rr-wfm/MSBuild.Sdk.SqlProj#publishing-support for supported publishing options -->
+    </PropertyGroup>
+</Project>

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/sqlproj.nuspec
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/sqlproj.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <description>$description$</description>
+    <authors>$authors$</authors>
+    <owners>$authors$</owners>
+    <copyright>$copyright$</copyright>
+    <projectUrl>$projecturl$</projectUrl>
+    <tags>$tags$</tags>
+    <packageTypes>
+      <packageType name="$packagetype$" />
+    </packageTypes>
+    <repository type="git" url="<repository-url>" />
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\$tfm$\*.dacpac" target="tools/" />
+  </files>
+</package>

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/table/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/table/.template.config/template.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer", "Table" ],
+    "identity": "MSBuild.Sdk.SqlProj.Table",
+    "name": "Database table",
+    "shortName": "table",
+    "tags": {
+      "language": "SQL",
+      "type": "item"
+    },
+    "sourceName": "Table1"
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/table/Table1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/table/Table1.sql
@@ -1,0 +1,4 @@
+CREATE TABLE [dbo].[Table1]
+(
+	[Id] INT NOT NULL PRIMARY KEY
+)

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/tablefunc/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/tablefunc/.template.config/template.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer", "TableFunction" ],
+    "identity": "MSBuild.Sdk.SqlProj.TableFunction",
+    "name": "Table-valued Function",
+    "shortName": "tablefunc",
+    "tags": {
+      "language": "SQL",
+      "type": "item"
+    },
+    "sourceName": "Function1"
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/tablefunc/Function1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/tablefunc/Function1.sql
@@ -1,0 +1,16 @@
+CREATE FUNCTION [dbo].[Function1]
+(
+	@param1 int,
+	@param2 char(5)
+)
+RETURNS @returntable TABLE
+(
+	c1 int,
+	c2 char(5)
+)
+AS
+BEGIN
+	INSERT @returntable
+	SELECT @param1, @param2
+	RETURN
+END

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/view/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/view/.template.config/template.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer", "View" ],
+    "identity": "MSBuild.Sdk.SqlProj.View",
+    "name": "Database view",
+    "shortName": "view",
+    "tags": {
+      "language": "SQL",
+      "type": "item"
+    },
+    "sourceName": "View1"
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/view/View1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/view/View1.sql
@@ -1,0 +1,2 @@
+CREATE VIEW [dbo].[View1]
+	AS SELECT * FROM [SomeTableOrView]


### PR DESCRIPTION
This adds a new NuGet package containing a set of templates that can be installed using `dotnet new`. It can then be used to create new projects that use MSBuild.Sdk.SqlProj. I've also included a set of item templates that can be used to quickly create new database objects. I've concentrated on the mostly used objects like tables, views and stored procedures for now, but other objects can be added fairly easily if needed.

The project template is created in such a way that it should align with the appropriate release of the SDK package. So if you have the MSBuild.Sdk.SqlProj.Templates 1.4.0 package installed and you create a new project using `dotnet new sqlproj` you get a `.csproj` with `Sdk="MSBuild.Sdk.SqlProj/1.4.0".

I've already tried this with the preview feature in VS 2019 16.8 preview 2 that lists templates installed with `dotnet new`. The template shows up, but when I create a project using the template I get a Project1.sql file instead of a Project1.csproj which is kinda weird. I guess that's a bug in Visual Studio though, because using `dotnet new` works just fine.

Fixes #24 