### PR TITLE
Add .NET 5.0 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET Core
       uses: coderpatros/setup-dotnet@sxs
       with:
-        dotnet-version: 2.1.809,3.1.401
+        dotnet-version: 2.1.809, 3.1.401, 5.0.100-preview.8.20417.9
 
     # Install Nerdbank.GitVersioning
     - name: install nbgv
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-18.04", "macos-10.15", "windows-2019" ]
-        dotnet: [ '2.1.809', '3.1.401' ]
+        dotnet: [ '2.1.809', '3.1.401', '5.0.100-preview.8.20417.9' ]
       fail-fast: false
 
     steps:
@@ -165,7 +165,7 @@ jobs:
 
     # Build the project using double wildcard (i.e. 1.*-*)
     - name: build project (double floating version / dotnet 3)
-      if: ${{ matrix.dotnet == '3.1.401' }}
+      if: ${{ matrix.dotnet != '2.1.809' }}
       run: dotnet build ./test/TestProjectWithSDKRef/TestProjectWithSDKRef.csproj /bl /p:DependencyVersion="1.*-*" /warnaserror:SQL71502
       shell: pwsh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET Core
       uses: coderpatros/setup-dotnet@sxs
       with:
-        dotnet-version: 2.1.808,3.1.302
+        dotnet-version: 2.1.809,3.1.401
 
     # Install Nerdbank.GitVersioning
     - name: install nbgv
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-18.04", "macos-10.15", "windows-2019" ]
-        dotnet: [ '2.1.808', '3.1.302' ]
+        dotnet: [ '2.1.809', '3.1.401' ]
       fail-fast: false
 
     steps:
@@ -165,12 +165,13 @@ jobs:
 
     # Build the project using double wildcard (i.e. 1.*-*)
     - name: build project (double floating version / dotnet 3)
-      if: ${{ matrix.dotnet == '3.1.302' }}
+      if: ${{ matrix.dotnet == '3.1.401' }}
       run: dotnet build ./test/TestProjectWithSDKRef/TestProjectWithSDKRef.csproj /bl /p:DependencyVersion="1.*-*" /warnaserror:SQL71502
       shell: pwsh
 
     # Upload dacpac
     - name: upload
+      if: ${{ matrix.os == 'ubuntu-18.04' && matrix.dotnet == '3.1.401' }}
       uses: actions/upload-artifact@v1
       with:
         name: dacpac-package
@@ -267,7 +268,7 @@ jobs:
     # Setup .NET SDK
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.302'
+        dotnet-version: '3.1.401'
 
     # Install Nerdbank.GitVersioning
     - name: install nbgv
@@ -313,7 +314,7 @@ jobs:
     # Setup .NET SDK
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.302'
+        dotnet-version: '3.1.401'
 
     # Download artifacts
     - name: download-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,7 +268,7 @@ jobs:
     # Setup .NET SDK
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.401'
+        dotnet-version: '5.0.100-preview.8.20417.9'
 
     # Install Nerdbank.GitVersioning
     - name: install nbgv
@@ -314,7 +314,7 @@ jobs:
     # Setup .NET SDK
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.401'
+        dotnet-version: '5.0.100-preview.8.20417.9'
 
     # Download artifacts
     - name: download-artifact

--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj
+++ b/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj
@@ -31,7 +31,7 @@
 
   <Target Name="IncludeDacpacTool" AfterTargets="Build">
     <PropertyGroup>
-      <_DacpacToolSupportedTfms>netcoreapp2.1;netcoreapp3.1</_DacpacToolSupportedTfms>
+      <_DacpacToolSupportedTfms>netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</_DacpacToolSupportedTfms>
     </PropertyGroup>
     <ItemGroup>
       <DacpacToolSupportedTfms Include="$(_DacpacToolSupportedTfms)" />


### PR DESCRIPTION
This adds support for .NET 5 previews so that folks having the preview installed can still build their projects without needing to put a `global.json` somewhere. Essentially this means that we're now building the `DacpacTool` for .NET 5 as well and include that into the `MSBuild.Sdk.SqlProj` package. At build time we pick the appropriate version depending on the .NET runtime included with the SDK.

I've also extended the CI pipeline to start building with .NET 5.0 as well. So far this seems to work just fine. We'll need to keep this up-to-date until the stable release hits in november.

Fixes #52 