### PR TITLE
Support for package references representing external databases

### DIFF
--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -10,7 +10,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public FileInfo Output { get; set; }
         public SqlServerVersion SqlServerVersion { get; set; }
         public FileInfo[] Input { get; set; }
-        public FileInfo[] Reference { get; set; }
+        public string[] Reference { get; set; }
         public string[] Property { get; set; }
         public string[] SqlCmdVar { get; set; }
         public FileInfo PreDeploy { get; set; }

--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SqlServer.DACFX" Version="150.4826.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20427.1" />
     <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/DacpacTool/Extensions.cs
+++ b/src/DacpacTool/Extensions.cs
@@ -2,12 +2,13 @@
 using System.IO;
 using System.Reflection;
 using Microsoft.SqlServer.Dac.Model;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
     public static class Extensions
     {
-        public static void AddReference(this TSqlModel model, string referencePath)
+        public static void AddReference(this TSqlModel model, string referencePath, string externalParts)
         {
             var dataSchemaModel = GetDataSchemaModel(model);
 
@@ -17,9 +18,13 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             setMetadataMethod.Invoke(customData, new object[] { "LogicalName", Path.GetFileName(referencePath) });
             setMetadataMethod.Invoke(customData, new object[] { "SuppressMissingDependenciesErrors", "False" });
 
+            if (!string.IsNullOrWhiteSpace(externalParts))
+            {
+                setMetadataMethod.Invoke(customData, new object[] { "ExternalParts", Identifier.EncodeIdentifier(externalParts) });
+            }
+
             AddCustomData(dataSchemaModel, customData);
         }
-
 
         public static void AddSqlCmdVariables(this TSqlModel model, string[] variableNames)
         {

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using Microsoft.Data.Tools.Schema.Sql.Packaging;
@@ -18,19 +21,34 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             Console.WriteLine($"Using SQL Server version {version}");
         }
 
-        public void AddReference(FileInfo referenceFile)
+        public void AddReference(string referenceFile)
         {
             // Ensure that the model has been created
             EnsureModelCreated();
 
             // Make sure the file exists
-            if (!referenceFile.Exists)
+            if (!File.Exists(referenceFile))
             {
                 throw new ArgumentException($"Unable to find reference file {referenceFile}", nameof(referenceFile));
             }
 
-            Console.WriteLine($"Adding reference to {referenceFile.FullName}");
-            Model.AddReference(referenceFile.FullName);
+            Console.WriteLine($"Adding reference to {referenceFile}");
+            Model.AddReference(referenceFile, null);
+        }
+
+        public void AddExternalReference(string referenceFile, string externalParts)
+        {
+            // Ensure that the model has been created
+            EnsureModelCreated();
+
+            // Make sure the file exists
+            if (!File.Exists(referenceFile))
+            {
+                throw new ArgumentException($"Unable to find reference file {referenceFile}", nameof(referenceFile));
+            }
+
+            Console.WriteLine($"Adding reference to {referenceFile} with external parts {externalParts}");
+            Model.AddReference(referenceFile, externalParts);
         }
 
         public void AddSqlCmdVariables(string[] variableNames)
@@ -78,8 +96,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             // Validate the model and write out validation messages
             int validationErrors = 0;
-            var messages = Model.Validate();
-            foreach (var message in messages)
+            var validationMessages = Model.Validate();
+            foreach (var message in validationMessages)
             {
                 if (message.MessageType == DacMessageType.Error)
                 {

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -70,7 +70,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             {
                 foreach (var reference in options.Reference)
                 {
-                    string[] referenceDetails = reference.Split(';', 2);
+                    string[] referenceDetails = reference.Split(';', 2, StringSplitOptions.RemoveEmptyEntries);
                     if (referenceDetails.Length == 1)
                     {
                         packageBuilder.AddReference(referenceDetails[0]);

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -19,7 +19,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<FileInfo>(new string[] { "--output", "-o" }, "Filename of the output package"),
                 new Option<SqlServerVersion>(new string[] { "--sqlServerVersion", "-sv" }, () => SqlServerVersion.Sql150, description: "Target version of the model"),
                 new Option<FileInfo[]>(new string[] { "--input", "-i" }, "Input file name(s)"),
-                new Option<FileInfo[]>(new string[] { "--reference", "-r" }, "Reference(s) to include"),
+                new Option<string[]>(new string[] { "--reference", "-r" }, "Reference(s) to include"),
                 new Option<FileInfo>(new string[] { "--predeploy" }, "Filename of optional pre-deployment script"),
                 new Option<FileInfo>(new string[] { "--postdeploy" }, "Filename of optional post-deployment script"),
                 new Option<FileInfo>(new string[] { "--refactorlog" }, "Filename of optional refactor log script"),
@@ -68,9 +68,17 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             // Add references to the model
             if (options.Reference != null)
             {
-                foreach (var referenceFile in options.Reference)
+                foreach (var reference in options.Reference)
                 {
-                    packageBuilder.AddReference(referenceFile);
+                    string[] referenceDetails = reference.Split(';', 2);
+                    if (referenceDetails.Length == 1)
+                    {
+                        packageBuilder.AddReference(referenceDetails[0]);
+                    }
+                    else
+                    {
+                        packageBuilder.AddExternalReference(referenceDetails[0], referenceDetails[1]);
+                    }
                 }
             }
 

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -124,6 +124,7 @@
         <PhysicalLocation Condition="'%(_ResolvedPackageReference.PhysicalLocation)'==''">$([System.String]::new('$(NuGetPackageRoot)%(PackageReference.Identity)/%(PackageReference.Version)').ToLower())</PhysicalLocation>
 
         <DacpacFile>%(_ResolvedPackageReference.PhysicalLocation)/tools/%(Identity).dacpac</DacpacFile>
+        <DatabaseVariableLiteralValue>%(PackageReference.DatabaseVariableLiteralValue)</DatabaseVariableLiteralValue>
       </_ResolvedPackageReference>
     
       <!-- Build a list of package references that include a dacpac file matching the package identity in their tools folder -->
@@ -150,7 +151,7 @@
       <OutputPathArgument>@(IntermediateAssembly->'-o &quot;%(Identity)&quot;', ' ')</OutputPathArgument>
       <MetadataArguments>-n &quot;$(MSBuildProjectName)&quot; -v &quot;$(PackageVersion)&quot;</MetadataArguments>
       <SqlServerVersionArgument>-sv $(SqlServerVersion)</SqlServerVersionArgument>
-      <ReferenceArguments>@(DacpacReference->'-r &quot;%(DacpacFile)&quot;', ' ')</ReferenceArguments>
+      <ReferenceArguments>@(DacpacReference->'-r &quot;%(DacpacFile);%(DatabaseVariableLiteralValue)&quot;', ' ')</ReferenceArguments>
       <InputFileArguments>@(Content->'-i &quot;%(FullPath)&quot;', ' ')</InputFileArguments>
       <PropertyArguments>@(PropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
       <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)', ' ')</SqlCmdVariableArguments>

--- a/test/DacpacTool.Tests/TestModelBuilder.cs
+++ b/test/DacpacTool.Tests/TestModelBuilder.cs
@@ -37,7 +37,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
 
         public TestModelBuilder AddReference(string path)
         {
-            sqlModel.AddReference(path);
+            sqlModel.AddReference(path, string.Empty);
             return this;
         }
 

--- a/test/TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReferencs.csproj
+++ b/test/TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReferencs.csproj
@@ -1,0 +1,15 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)../../src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <SqlServerVersion>Sql110</SqlServerVersion>
+    <RestoreAdditionalProjectSources>../TestProject/bin/Debug</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TestProject" Version="1.2.0-beta.9.gf2d69b1c16" DatabaseVariableLiteralValue="SomeOtherDatabase" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)../../src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets" />
+</Project>

--- a/test/TestProjectWithExternalPackageReference/csp_Test.sql
+++ b/test/TestProjectWithExternalPackageReference/csp_Test.sql
@@ -1,0 +1,5 @@
+CREATE PROCEDURE [dbo].[csp_Test]
+AS
+BEGIN
+    SELECT * FROM [SomeOtherDatabase].[dbo].[MyTable];
+END


### PR DESCRIPTION
So far we've only had support for package references that represent objects within the same database so that you can define SQL objects in a separate project, package that up into a NuGet package and then re-use those objects in your own project. The old SSDT projects also support adding a reference to another `.dacpac` where that reference represents an entirely different database. This PR adds that support to `MSBuild.Sdk.SqlProj` as well which is controlled by setting the `DatabaseVariableLiteralValue` item metadata on the `PackageReference`, similar to how this works in SSDT projects.

Fixes #51 