### PR TITLE
Use an intermediate file containing each object definition

### DIFF
--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -9,7 +9,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public string Version { get; set; }
         public FileInfo Output { get; set; }
         public SqlServerVersion SqlServerVersion { get; set; }
-        public FileInfo[] Input { get; set; }
         public string InputFile { get; set; }
         public string[] Reference { get; set; }
         public string[] Property { get; set; }

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -9,7 +9,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public string Version { get; set; }
         public FileInfo Output { get; set; }
         public SqlServerVersion SqlServerVersion { get; set; }
-        public string InputFile { get; set; }
+        public FileInfo InputFile { get; set; }
         public string[] Reference { get; set; }
         public string[] Property { get; set; }
         public string[] SqlCmdVar { get; set; }

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -10,6 +10,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public FileInfo Output { get; set; }
         public SqlServerVersion SqlServerVersion { get; set; }
         public FileInfo[] Input { get; set; }
+        public string InputFile { get; set; }
         public string[] Reference { get; set; }
         public string[] Property { get; set; }
         public string[] SqlCmdVar { get; set; }

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -18,7 +18,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<string>(new string[] { "--version", "-v" }, "Version of the package"),
                 new Option<FileInfo>(new string[] { "--output", "-o" }, "Filename of the output package"),
                 new Option<SqlServerVersion>(new string[] { "--sqlServerVersion", "-sv" }, () => SqlServerVersion.Sql150, description: "Target version of the model"),
-                new Option<FileInfo[]>(new string[] { "--input", "-i" }, "Input file name(s)"),
+                new Option<FileInfo[]>(new string[] { "--input", "-i" }, "Input file name(s)"), // DEPRECATED: Prefer InputFile instead
+                new Option<string>(new string[] { "--inputfile", "-f" }, "Text file listing all input files"),
                 new Option<string[]>(new string[] { "--reference", "-r" }, "Reference(s) to include"),
                 new Option<FileInfo>(new string[] { "--predeploy" }, "Filename of optional pre-deployment script"),
                 new Option<FileInfo>(new string[] { "--postdeploy" }, "Filename of optional post-deployment script"),
@@ -89,11 +90,29 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             }
 
             // Add input files
+            // DEPRECATED: Prefer InputFile instead -- Input can cause the maximum command size to be exceeded on Windows
             if (options.Input != null)
             {
                 foreach (var inputFile in options.Input)
                 {
                     packageBuilder.AddInputFile(inputFile);
+                }
+            }
+
+            // Add input files by iterating through $Project.InputFiles.txt
+            if (options.InputFile != null)
+            {
+                if (File.Exists(options.InputFile))
+                {
+                    foreach (var line in File.ReadLines(options.InputFile))
+                    {
+                        FileInfo inputFile = new FileInfo(line); // Validation occurs in AddInputFile
+                        packageBuilder.AddInputFile(inputFile);
+                    }
+                }
+                else 
+                {
+                    throw new ArgumentException($"No input files found, missing {options.InputFile}");
                 }
             }
 

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -18,8 +18,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<string>(new string[] { "--version", "-v" }, "Version of the package"),
                 new Option<FileInfo>(new string[] { "--output", "-o" }, "Filename of the output package"),
                 new Option<SqlServerVersion>(new string[] { "--sqlServerVersion", "-sv" }, () => SqlServerVersion.Sql150, description: "Target version of the model"),
-                new Option<FileInfo[]>(new string[] { "--input", "-i" }, "Input file name(s)"), // DEPRECATED: Prefer InputFile instead
-                new Option<string>(new string[] { "--inputfile", "-f" }, "Text file listing all input files"),
+                new Option<string>(new string[] { "--inputfile", "-i" }, "Text file listing all input files"),
                 new Option<string[]>(new string[] { "--reference", "-r" }, "Reference(s) to include"),
                 new Option<FileInfo>(new string[] { "--predeploy" }, "Filename of optional pre-deployment script"),
                 new Option<FileInfo>(new string[] { "--postdeploy" }, "Filename of optional post-deployment script"),
@@ -87,16 +86,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             if (options.SqlCmdVar != null)
             {
                 packageBuilder.AddSqlCmdVariables(options.SqlCmdVar);
-            }
-
-            // Add input files
-            // DEPRECATED: Prefer InputFile instead -- Input can cause the maximum command size to be exceeded on Windows
-            if (options.Input != null)
-            {
-                foreach (var inputFile in options.Input)
-                {
-                    packageBuilder.AddInputFile(inputFile);
-                }
             }
 
             // Add input files by iterating through $Project.InputFiles.txt

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -18,7 +18,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<string>(new string[] { "--version", "-v" }, "Version of the package"),
                 new Option<FileInfo>(new string[] { "--output", "-o" }, "Filename of the output package"),
                 new Option<SqlServerVersion>(new string[] { "--sqlServerVersion", "-sv" }, () => SqlServerVersion.Sql150, description: "Target version of the model"),
-                new Option<string>(new string[] { "--inputfile", "-i" }, "Text file listing all input files"),
+                new Option<FileInfo>(new string[] { "--inputfile", "-i" }, "Text file listing all input files"),
                 new Option<string[]>(new string[] { "--reference", "-r" }, "Reference(s) to include"),
                 new Option<FileInfo>(new string[] { "--predeploy" }, "Filename of optional pre-deployment script"),
                 new Option<FileInfo>(new string[] { "--postdeploy" }, "Filename of optional post-deployment script"),
@@ -91,9 +91,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             // Add input files by iterating through $Project.InputFiles.txt
             if (options.InputFile != null)
             {
-                if (File.Exists(options.InputFile))
+                if (options.InputFile.Exists)
                 {
-                    foreach (var line in File.ReadLines(options.InputFile))
+                    foreach (var line in File.ReadLines(options.InputFile.FullName))
                     {
                         FileInfo inputFile = new FileInfo(line); // Validation occurs in AddInputFile
                         packageBuilder.AddInputFile(inputFile);
@@ -101,7 +101,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 }
                 else 
                 {
-                    throw new ArgumentException($"No input files found, missing {options.InputFile}");
+                    throw new ArgumentException($"No input files found, missing {options.InputFile.Name}");
                 }
             }
 

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -158,7 +158,7 @@
       <MetadataArguments>-n &quot;$(MSBuildProjectName)&quot; -v &quot;$(PackageVersion)&quot;</MetadataArguments>
       <SqlServerVersionArgument>-sv $(SqlServerVersion)</SqlServerVersionArgument>
       <ReferenceArguments>@(DacpacReference->'-r &quot;%(DacpacFile);%(DatabaseVariableLiteralValue)&quot;', ' ')</ReferenceArguments>
-      <InputFileArguments>-f &quot;$(IntermediateOutputPath)$(MSBuildProjectName).InputFiles.txt&quot;</InputFileArguments>
+      <InputFileArguments>-i &quot;$(IntermediateOutputPath)$(MSBuildProjectName).InputFiles.txt&quot;</InputFileArguments>
       <PropertyArguments>@(PropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
       <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)', ' ')</SqlCmdVariableArguments>
       <PreDeploymentScriptArgument>@(PreDeploy->'--predeploy %(Identity)', ' ')</PreDeploymentScriptArgument>

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -147,7 +147,7 @@
       <IncludedDacpacReferenceFiles Include="@(DacpacReference->'%(DacpacFile)')" />
     </ItemGroup>
     <!-- Write the list of input files to a file to be consumed by the dacpac tool -->
-    <Message Importance="Low" Text="Writing input files to $(IntermediateOutputPath)$(MSBuildProjectName)InputFiles.txt" />
+    <Message Importance="Low" Text="Writing input files to $(IntermediateOutputPath)$(MSBuildProjectName).InputFiles.txt" />
     <WriteLinesToFile
       File="$(IntermediateOutputPath)$(MSBuildProjectName).InputFiles.txt"
       Overwrite="true"

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -146,13 +146,19 @@
       </PropertyNames>
       <IncludedDacpacReferenceFiles Include="@(DacpacReference->'%(DacpacFile)')" />
     </ItemGroup>
+    <!-- Write the list of input files to a file to be consumed by the dacpac tool -->
+    <Message Importance="Low" Text="Writing input files to $(IntermediateOutputPath)$(MSBuildProjectName)InputFiles.txt" />
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)$(MSBuildProjectName).InputFiles.txt"
+      Overwrite="true"
+      Lines="@(Content)" />
     <!-- Build arguments for the command line tool  -->
     <PropertyGroup>
       <OutputPathArgument>@(IntermediateAssembly->'-o &quot;%(Identity)&quot;', ' ')</OutputPathArgument>
       <MetadataArguments>-n &quot;$(MSBuildProjectName)&quot; -v &quot;$(PackageVersion)&quot;</MetadataArguments>
       <SqlServerVersionArgument>-sv $(SqlServerVersion)</SqlServerVersionArgument>
       <ReferenceArguments>@(DacpacReference->'-r &quot;%(DacpacFile);%(DatabaseVariableLiteralValue)&quot;', ' ')</ReferenceArguments>
-      <InputFileArguments>@(Content->'-i &quot;%(FullPath)&quot;', ' ')</InputFileArguments>
+      <InputFileArguments>-f &quot;$(IntermediateOutputPath)$(MSBuildProjectName).InputFiles.txt&quot;</InputFileArguments>
       <PropertyArguments>@(PropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
       <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)', ' ')</SqlCmdVariableArguments>
       <PreDeploymentScriptArgument>@(PreDeploy->'--predeploy %(Identity)', ' ')</PreDeploymentScriptArgument>


### PR DESCRIPTION
I've left the existing code for `--input`, just in case anyone is trying to call the DacpacTool CLI directly, but added `--inputfile` and changed `Sdk.targets` to use that instead. The new intermediate file is added to the `obj/` directory.