### PR TITLE
Add additional item templates and schema name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ Then run a `dotnet build` and you'll find a .dacpac file in the `bin\Debug\netst
 
 | Template | Command | Description |
 | --- | --- | --- |
-| table | `dotnet new table -n <name>` | Creates a new database table with the provided name |
-| view | `dotnet new view -n <name>` | Creates a new database view with the provided name |
-| sproc | `dotnet new sproc -n <name>` | Creates a new stored procedure with the provided name |
-| inlinefunc | `dotnet new inlinefunc -n <name>` | Creates a new inline function with the provided name |
-| tablefunc | `dotnet new tablefunc -n <name>` | Creates a new table-valued function with the provided name |
-| scalarfunc | `dotnet new scalarfunc -n <name>` | Creates a new scalar function with the provided name |
+| table | `dotnet new table -n <name> [-s <schema-name>]` | Creates a new database table with the provided name |
+| view | `dotnet new view -n <name> [-s <schema-name>]` | Creates a new database view with the provided name |
+| sproc | `dotnet new sproc -n <name> [-s <schema-name>]` | Creates a new stored procedure with the provided name |
+| inlinefunc | `dotnet new inlinefunc -n <name> [-s <schema-name>]` | Creates a new inline function with the provided name |
+| tablefunc | `dotnet new tablefunc -n <name> [-s <schema-name>]` | Creates a new table-valued function with the provided name |
+| scalarfunc | `dotnet new scalarfunc -n <name> [-s <schema-name>]` | Creates a new scalar function with the provided name |
+| uddt | `dotnet new uddt -n <name> [-s <schema-name>]` | Creates a new user-defined data type with the provided name |
+| udtt | `dotnet new udtt -n <name> [-s <schema-name>]` | Creates a new user-defined table type with the provided name |
 
 > Note: In a future update of Visual Studio you should be able to use both the project template and the item templates directly from Visual Studio. This feature is currently in preview and some of our early testing has revealed that it doesn't work as expected. Stay tuned for updates on this.
 

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/inlinefunc/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/inlinefunc/.template.config/template.json
@@ -9,5 +9,13 @@
       "language": "SQL",
       "type": "item"
     },
-    "sourceName": "Function1"
+    "sourceName": "Function1",
+    "symbols": {
+      "schemaName": {
+        "type": "parameter",
+        "defaultValue": "dbo",
+        "replaces": "#{SchemaName}",
+        "description": "Name of the schema to place the inline function in. Defaults to 'dbo'."
+      }
+    }
   }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/inlinefunc/Function1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/inlinefunc/Function1.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION [dbo].[Function1]
+CREATE FUNCTION [#{SchemaName}].[Function1]
 (
 	@param1 int,
 	@param2 char(5)

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/scalarfunc/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/scalarfunc/.template.config/template.json
@@ -9,5 +9,13 @@
       "language": "SQL",
       "type": "item"
     },
-    "sourceName": "Function1"
+    "sourceName": "Function1",
+    "symbols": {
+      "schemaName": {
+        "type": "parameter",
+        "defaultValue": "dbo",
+        "replaces": "#{SchemaName}",
+        "description": "Name of the schema to place the scalar function in. Defaults to 'dbo'."
+      }
+    }
   }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/scalarfunc/Function1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/scalarfunc/Function1.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION [dbo].[Function1]
+CREATE FUNCTION [#{SchemaName}].[Function1]
 (
 	@param1 int,
 	@param2 int

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sproc/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sproc/.template.config/template.json
@@ -9,5 +9,13 @@
       "language": "SQL",
       "type": "item"
     },
-    "sourceName": "Procedure1"
+    "sourceName": "Procedure1",
+    "symbols": {
+      "schemaName": {
+        "type": "parameter",
+        "defaultValue": "dbo",
+        "replaces": "#{SchemaName}",
+        "description": "Name of the schema to place the stored procedure function in. Defaults to 'dbo'."
+      }
+    }
   }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sproc/Procedure1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sproc/Procedure1.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE [dbo].[Procedure1]
+CREATE PROCEDURE [#{SchemaName}].[Procedure1]
 	@param1 int = 0,
 	@param2 int
 AS

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/table/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/table/.template.config/template.json
@@ -9,5 +9,13 @@
       "language": "SQL",
       "type": "item"
     },
-    "sourceName": "Table1"
+    "sourceName": "Table1",
+    "symbols": {
+      "schemaName": {
+        "type": "parameter",
+        "defaultValue": "dbo",
+        "replaces": "#{SchemaName}",
+        "description": "Name of the schema to place the table in. Defaults to 'dbo'."
+      }
+    }
   }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/table/Table1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/table/Table1.sql
@@ -1,4 +1,4 @@
-CREATE TABLE [dbo].[Table1]
+CREATE TABLE [#{SchemaName}].[Table1]
 (
 	[Id] INT NOT NULL PRIMARY KEY
 )

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/tablefunc/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/tablefunc/.template.config/template.json
@@ -9,5 +9,13 @@
       "language": "SQL",
       "type": "item"
     },
-    "sourceName": "Function1"
+    "sourceName": "Function1",
+    "symbols": {
+      "schemaName": {
+        "type": "parameter",
+        "defaultValue": "dbo",
+        "replaces": "#{SchemaName}",
+        "description": "Name of the schema to place the table-valued function in. Defaults to 'dbo'."
+      }
+    }
   }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/tablefunc/Function1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/tablefunc/Function1.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION [dbo].[Function1]
+CREATE FUNCTION [#{SchemaName}].[Function1]
 (
 	@param1 int,
 	@param2 char(5)

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/uddt/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/uddt/.template.config/template.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer", "UserDefinedDataType" ],
+    "identity": "MSBuild.Sdk.SqlProj.UserDefinedDataType",
+    "name": "User-defined data type",
+    "shortName": "uddt",
+    "tags": {
+      "language": "SQL",
+      "type": "item"
+    },
+    "sourceName": "UserDefinedDataType1",
+    "symbols": {
+      "schemaName": {
+        "type": "parameter",
+        "defaultValue": "dbo",
+        "replaces": "#{SchemaName}",
+        "description": "Name of the schema to place the user-defined data type in. Defaults to 'dbo'."
+      }
+    }
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/uddt/UserDefinedDataType1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/uddt/UserDefinedDataType1.sql
@@ -1,0 +1,2 @@
+CREATE TYPE [#{SchemaName}].[UserDefinedDataType1]
+	FROM varchar(11) NOT NULL

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/udtt/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/udtt/.template.config/template.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "MSBuild.Sdk.SqlProj",
+    "classifications": [ "Database", "SqlServer", "UserDefinedTableType" ],
+    "identity": "MSBuild.Sdk.SqlProj.UserDefinedTableType",
+    "name": "User-defined table type",
+    "shortName": "udtt",
+    "tags": {
+      "language": "SQL",
+      "type": "item"
+    },
+    "sourceName": "UserDefinedTableType1",
+    "symbols": {
+      "schemaName": {
+        "type": "parameter",
+        "defaultValue": "dbo",
+        "replaces": "#{SchemaName}",
+        "description": "Name of the schema to place the user-defined table type in. Defaults to 'dbo'."
+      }
+    }
+  }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/udtt/UserDefinedTableType1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/udtt/UserDefinedTableType1.sql
@@ -1,0 +1,4 @@
+CREATE TYPE [#{SchemaName}].[UserDefinedTableType1] AS TABLE
+(
+	Id INT, Name VARCHAR(128)
+)

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/view/.template.config/template.json
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/view/.template.config/template.json
@@ -9,5 +9,13 @@
       "language": "SQL",
       "type": "item"
     },
-    "sourceName": "View1"
+    "sourceName": "View1",
+    "symbols": {
+      "schemaName": {
+        "type": "parameter",
+        "defaultValue": "dbo",
+        "replaces": "#{SchemaName}",
+        "description": "Name of the schema to place the view in. Defaults to 'dbo'."
+      }
+    }
   }

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/view/View1.sql
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/view/View1.sql
@@ -1,2 +1,2 @@
-CREATE VIEW [dbo].[View1]
+CREATE VIEW [#{SchemaName}].[View1]
 	AS SELECT * FROM [SomeTableOrView]


### PR DESCRIPTION
This adds two new item templates to the template pack introduced in 1.4.0, namely user-defined data types and user-defined table types. We are using the latter quite a lot. I've also added a schemaName parameter to all of the item templates so that you can run `dotnet new sproc -n MyStoredProcedure -s MySchema` and immediately have a stored procedure with the correct name and schema created for you.