### PR TITLE
Add support for project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dotnet new sqlproj [-s Sql150]
 You should now have a project file with the following contents:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.6.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <SqlServerVersion>Sql150</SqlServerVersion>
@@ -64,7 +64,7 @@ If you already have a SSDT (.sqlproj) project in your solution, you can keep tha
 There are a lot of properties that can be set on the model in the resulting `.dacpac` file which can be influenced by setting those properties in the project file using the same name. For example, the snippet below sets the `RecoveryMode` property to `Simple`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.6.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <RecoveryMode>Simple</RecoveryMode>
@@ -85,7 +85,7 @@ Support for pre- and post deployment scripts has been added in version 1.1.0. Th
 To include these scripts into your `.dacpac` add the following to your `.csproj`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.6.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -101,7 +101,7 @@ To include these scripts into your `.dacpac` add the following to your `.csproj`
 Especially when using pre- and post deployment scripts, but also in other scenario's, it might be useful to define variables that can be controlled at deployment time. This is supported through the use of SQLCMD variables, added in version 1.1.0. These variables can be defined in your project file using the following syntax:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.6.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -123,7 +123,7 @@ Especially when using pre- and post deployment scripts, but also in other scenar
 `MSBuild.Sdk.SqlProj` supports referencing NuGet packages that contain `.dacpac` packages. These can be referenced by using the `PackageReference` format familiar to .NET developers. They can also be installed through the NuGet Package Manager in Visual Studio.
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.6.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -137,7 +137,7 @@ Especially when using pre- and post deployment scripts, but also in other scenar
 It will assume that the `.dacpac` file is inside the `tools` folder of the referenced package and that it has the same name as the NuGet package. Referenced packages that do not adhere to this convention will be silently ignored. By default the package reference is treated as being part of the same database. For example, if the reference package contains a `.dacpac` that has a table and a stored procedure and you would `dotnet publish` the project the table and stored procedure from that package will be deployed along with the contents of your project to the same database. If this is not desired, you can add the `DatabaseVariableLiteralValue` item metadata to the `PackageReference` specifying a different database name:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.6.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -162,6 +162,37 @@ sqlpackage
     /TargetPassword: MyP@ssword \
     /Properties:IncludeCompositeObjects=True
 ```
+
+## Project references
+Similar to package references you can also reference another project by using a `ProjectReference`. These references can be added manually to the project file or they can be added through Visual Studio. For example, consider the following example:
+
+```xml
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../MyOtherProject/MyOtherProject.csproj" />
+    </ItemGroup>
+</Project>
+```
+
+This will ensure that `MyOtherProject` is build first and the resulting `.dacpac` will be reference by this project. This means you can use the objects defined in the other project within the scope of this project. If the other project is representing an entirely different database you can also use `DatabaseVariableLiteralValue` attribute on the `ProjectReference` similar to `PackageReference`:
+
+```xml
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../MyOtherProject/MyOtherProject.csproj" DatabaseVariableLiteralValue="SomeOtherDatabase" />
+    </ItemGroup>
+</Project>
+```
+
+> Note: We do not support adding a `ProjectReference` to an existing `.sqlproj` file.
 
 ## Packaging support
 `MSBuild.Sdk.SqlProj` supports packaging your project into a [NuGet](https://www.nuget.org) package using the `dotnet pack` command. In order for this to work, you'll need to add a `.nuspec` file next to your project file with the same name. For example, if your `.csproj` is called `TestProject.csproj` you'll need to add a `TestProject.nuspec` file in the same folder. Fill this file with the following contents and replace the placeholder with the appropriate value:
@@ -194,7 +225,7 @@ sqlpackage
 Additionally you'll need to set the `PackageProjectUrl` property inside of the `.csproj` like this:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.6.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
   <PropertyGroup>
     ...
     <PackageProjectUrl>your-project-url</PackageProjectUrl>
@@ -227,7 +258,7 @@ To further customize the deployment process, you can use the following propertie
 In addition to these properties, you can also set any of the [documented](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.dac.dacdeployoptions?view=sql-dacfx-150) deployment options. These are typically set in the project file, for example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.6.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.9.0">
     <PropertyGroup>
         ...
         <BackupDatabaseBeforeChanges>True</BackupDatabaseBeforeChanges>

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -80,7 +80,7 @@
   <!--
     The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable it is to override it with an empty target.
   -->
-  <Target Name="GetTargetPathWithTargetPlatformMoniker" />
+  <!--<Target Name="GetTargetPathWithTargetPlatformMoniker" />-->
 
   <Import Project="$(CustomAfterNoTargets)" Condition="'$(CustomAfterNoTargets)' != '' and Exists('$(CustomAfterNoTargets)')" />
 
@@ -109,7 +109,7 @@
     Resolves package references to .dacpac packages by enumerating all package references, resolving their associated Pkg<package-id> property to get the physical
     location of the package and then checking if a that package contains a .dacpac file inside of the tools folder.
   -->
-  <Target Name="ResolveDatabasePackageReferences">
+  <Target Name="ResolveDatabaseReferences">
     <ItemGroup> 
       <!-- Resolve all package references to their physical location first -->
       <_ResolvedPackageReference Include="%(PackageReference.Identity)">
@@ -126,9 +126,15 @@
         <DacpacFile>%(_ResolvedPackageReference.PhysicalLocation)/tools/%(Identity).dacpac</DacpacFile>
         <DatabaseVariableLiteralValue>%(PackageReference.DatabaseVariableLiteralValue)</DatabaseVariableLiteralValue>
       </_ResolvedPackageReference>
+
+      <!-- Resolve all project references to their physical location -->
+      <_ResolvedProjectReference Include="%(_ResolvedProjectReferencePaths.Identity)">
+        <DacpacFile>%(_ResolvedProjectReferencePaths.Identity)</DacpacFile>
+        <DatabaseVariableLiteralValue>%(_ResolvedProjectReferencePaths.DatabaseVariableLiteralValue)</DatabaseVariableLiteralValue>
+      </_ResolvedProjectReference>
     
-      <!-- Build a list of package references that include a dacpac file matching the package identity in their tools folder -->
-      <DacpacReference Include="@(_ResolvedPackageReference)" Condition="Exists(%(DacpacFile))" />
+      <!-- Build a list of package/project references that include a dacpac file matching the package identity in their tools folder -->
+      <DacpacReference Include="@(_ResolvedPackageReference);@(_ResolvedProjectReference)" Condition="Exists(%(DacpacFile))" />
     </ItemGroup>
 
     <Message Importance="normal" Text="Resolved dacpac file from package %(_ResolvedPackageReference.Identity) to %(_ResolvedPackageReference.DacpacFile)" />
@@ -158,13 +164,16 @@
   <!--
     Performs the actual compilation of the input files (*.sql) into a .dacpac package by calling into a command line tool to do the actual work.
   -->
-  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabasePackageReferences;GetIncludedFiles" 
+  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabaseReferences;GetIncludedFiles" 
           Inputs="@(Content);@(PreDeploy);@(PostDeploy);@(RefactorLog);$(IncludedFiles);$(ProjectPath)" Outputs="$(TargetPath)">
     <ItemGroup>
+      <!-- Get the values for known model properties specified in the project file -->
       <_PropertyNames Include="$(KnownModelProperties)" />
       <PropertyNames Include="@(_PropertyNames)" Condition=" '$(%(Identity))' != '' ">
         <PropertyValue>$(%(_PropertyNames.Identity))</PropertyValue>
       </PropertyNames>
+      
+      <!-- Compile the list of references -->
       <IncludedDacpacReferenceFiles Include="@(DacpacReference->'%(DacpacFile)')" />
     </ItemGroup>
     <!-- Write the list of input files to a file to be consumed by the dacpac tool -->

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -76,12 +76,6 @@
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets" 
           Condition="'$(DebuggerFlavor)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')" />
 
-
-  <!--
-    The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable it is to override it with an empty target.
-  -->
-  <!--<Target Name="GetTargetPathWithTargetPlatformMoniker" />-->
-
   <Import Project="$(CustomAfterNoTargets)" Condition="'$(CustomAfterNoTargets)' != '' and Exists('$(CustomAfterNoTargets)')" />
 
   <!-- 

--- a/test/TestProjectWithProjectReference/TestProjectWithProjectReference.csproj
+++ b/test/TestProjectWithProjectReference/TestProjectWithProjectReference.csproj
@@ -1,0 +1,19 @@
+<Project>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <SqlServerVersion>Sql150</SqlServerVersion>
+        <!-- For additional properties that can be set here, please refer to https://github.com/rr-wfm/MSBuild.Sdk.SqlProj#model-properties -->
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- Refer to https://github.com/rr-wfm/MSBuild.Sdk.SqlProj#publishing-support for supported publishing options -->
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../TestProject/TestProject.csproj" DatabaseVariableLiteralValue="SomeOtherDatabase" />
+    </ItemGroup>
+
+    <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+</Project>


### PR DESCRIPTION
In addition to package references you might also want to reference another project (possibly within the same solution). This adds support for that. Luckily most of the heavy lifting is already done for us, so all we really needed to do is to make sure we support getting a target path of the `.dacpac` without building the project and then resolving that target path into a reference parameter for the `DacpacTool`.

Fixes #40 