### PR TITLE
Fix up-to-date-check issue

### DIFF
--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -35,6 +35,8 @@
   <PropertyGroup>
     <TargetExt>.dacpac</TargetExt>
     <TargetPath>$(TargetDir)/$(MSBuildProjectName)$(TargetExt)</TargetPath>
+    <!--We won't be generating debug symbols here -->
+    <_DebugSymbolsProduced>false</_DebugSymbolsProduced>
     <CoreBuildDependsOn>
       BuildOnlySettings;
       PrepareForBuild;


### PR DESCRIPTION
We discovered an issue with the Fast Up-to-date check feature of Visual Studio. It seemed to be looking for debug symbols, but they are never produced by an MSBuild.Sdk.SqlProj project. So we made that explicit now, which seems to fix the issue with fast-up-to-date check.

Fixes: #74 