### PR TITLE
Improved error handling for publish pipeline

### DIFF
--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -92,12 +92,33 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             try
             {
                 var services = new DacServices(ConnectionStringBuilder.ConnectionString);
+                services.Message += HandleDacServicesMessage;
                 services.Deploy(Package, targetDatabaseName, true, DeployOptions);
                 _console.WriteLine($"Successfully deployed database '{targetDatabaseName}'");
             }
-            catch (Exception ex)
+            catch (DacServicesException ex)
             {
-                _console.WriteLine($"ERROR: Deployment of database '{targetDatabaseName}' failed: {ex.Message}");
+                if (ex.InnerException != null)
+                {
+                    _console.WriteLine($"ERROR: Deployment of database '{targetDatabaseName}' failed: {ex.InnerException.Message}");
+                }
+                else
+                {
+                    _console.WriteLine($"ERROR: Deployment of database '{targetDatabaseName}' failed: {ex.Message}");
+                }
+            }
+        }
+
+        private void HandleDacServicesMessage(object sender, DacMessageEventArgs args)
+        {
+            var message = args.Message;
+            if (message.MessageType == DacMessageType.Message)
+            {
+                _console.WriteLine(message.Message);
+            }
+            else
+            {
+                _console.WriteLine($"{message.MessageType} {message.Prefix}{message.Number}: {message.Message}");
             }
         }
 

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -107,6 +107,10 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     _console.WriteLine($"ERROR: Deployment of database '{targetDatabaseName}' failed: {ex.Message}");
                 }
             }
+            catch (Exception ex)
+            {
+                _console.WriteLine($"ERROR: An unknown error occurred while deploying database '{targetDatabaseName}': {ex.Message}");
+            }
         }
 
         private void HandleDacServicesMessage(object sender, DacMessageEventArgs args)

--- a/test/TestProject/TestProject.csproj
+++ b/test/TestProject/TestProject.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <SqlServerVersion>Sql110</SqlServerVersion>
+    <SqlServerVersion>Sql150</SqlServerVersion>
     <RecoveryMode>Simple</RecoveryMode>
     <AllowSnapshotIsolation>True</AllowSnapshotIsolation>
     <ReadCommittedSnapshot>True</ReadCommittedSnapshot>

--- a/test/TestProjectWithErrors/TestProjectWithErrors.csproj
+++ b/test/TestProjectWithErrors/TestProjectWithErrors.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <SqlServerVersion>Sql110</SqlServerVersion>
+    <SqlServerVersion>Sql150</SqlServerVersion>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />

--- a/test/TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReferencs.csproj
+++ b/test/TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReferencs.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <SqlServerVersion>Sql110</SqlServerVersion>
+    <SqlServerVersion>Sql150</SqlServerVersion>
     <RestoreAdditionalProjectSources>../TestProject/bin/Debug</RestoreAdditionalProjectSources>
   </PropertyGroup>
 

--- a/test/TestProjectWithPackageReference/TestProjectWithPackageReference.csproj
+++ b/test/TestProjectWithPackageReference/TestProjectWithPackageReference.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <SqlServerVersion>Sql110</SqlServerVersion>
+    <SqlServerVersion>Sql150</SqlServerVersion>
     <RestoreAdditionalProjectSources>../TestProject/bin/Debug</RestoreAdditionalProjectSources>
   </PropertyGroup>
 

--- a/test/TestProjectWithPrePost/TestProjectWithPrePost.csproj
+++ b/test/TestProjectWithPrePost/TestProjectWithPrePost.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <SqlServerVersion>Sql110</SqlServerVersion>
+    <SqlServerVersion>Sql150</SqlServerVersion>
     <RecoveryMode>Simple</RecoveryMode>
     <AllowSnapshotIsolation>True</AllowSnapshotIsolation>
     <ReadCommittedSnapshot>True</ReadCommittedSnapshot>

--- a/test/TestProjectWithWarnings/TestProjectWithWarnings.csproj
+++ b/test/TestProjectWithWarnings/TestProjectWithWarnings.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <SqlServerVersion>Sql110</SqlServerVersion>
+    <SqlServerVersion>Sql150</SqlServerVersion>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />


### PR DESCRIPTION
As mentioned in #70 the output for the publish pipeline isn't ideal which leads to users having to figure out by themselves what's going wrong. This PR changes the way we handle exceptions by looking for an InnerException and writing the message from that, rather than the `DacServicesException` which tells us nothing more than that the deployment failed.

I've also hooked up the `Message` event so that we get some more output from the deployment. Essentially you now get the same output as you would get when running `SqlPackage.exe` which can be useful to diagnose problems.

Fixes: #70 