### PR TITLE
Allow specifying an alternative file name for the .dacpac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET Core
       uses: coderpatros/setup-dotnet@sxs
       with:
-        dotnet-version: 2.1.809, 3.1.401, 5.0.100-preview.8.20417.9
+        dotnet-version: 2.1.809, 3.1.401, 5.0.100-rc.1.20452.10
 
     # Install Nerdbank.GitVersioning
     - name: install nbgv
@@ -102,7 +102,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-18.04", "macos-10.15", "windows-2019" ]
-        dotnet: [ '2.1.809', '3.1.401', '5.0.100-preview.8.20417.9' ]
+        dotnet: [ '2.1.809', '3.1.401', '5.0.100-rc.1.20452.10' ]
       fail-fast: false
 
     steps:
@@ -269,7 +269,7 @@ jobs:
     # Setup .NET SDK
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100-preview.8.20417.9'
+        dotnet-version: '5.0.100-rc.1.20452.10'
 
     # Install Nerdbank.GitVersioning
     - name: install nbgv
@@ -315,7 +315,7 @@ jobs:
     # Setup .NET SDK
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100-preview.8.20417.9'
+        dotnet-version: '5.0.100-rc.1.20452.10'
 
     # Download artifacts
     - name: download-artifact

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ You should now have a project file with the following contents:
 </Project>
 ```
 
-Then run a `dotnet build` and you'll find a .dacpac file in the `bin\Debug\netstandard2.0` folder. By default all `.sql` files will be added to the package, except for those in the `Pre-Deployment` and `Post-Deployment` folders. To create database objects you can use the following item templates:
+Then run a `dotnet build` and you'll find a .dacpac file with the same name as your project file in the `bin\Debug\netstandard2.0` folder. If you want to change the name of the `.dacpac` file you can set the `<TargetName>` property in your project file to something else.
+
+> Note: For PackageReferences this SDK currently assumes that the `.dacpac` file has the same name as the package. If you plan to create a NuGet package out of your project (see [below](#packaging-support)) then make sure that `<TargetName>` matches the ID of your package.
+
+By default all `.sql` files will be added to the package, except for those in the `Pre-Deployment` and `Post-Deployment` folders. To create database objects you can use the following item templates:
 
 | Template | Command | Description |
 | --- | --- | --- |

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
@@ -9,6 +9,7 @@
     <UsingMSBuildSdkSqlProj>true</UsingMSBuildSdkSqlProj>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
     <SqlServerVersion>Sql150</SqlServerVersion>
+    <TargetExt>.dacpac</TargetExt>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -33,8 +33,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetExt>.dacpac</TargetExt>
-    <TargetPath>$(TargetDir)/$(MSBuildProjectName)$(TargetExt)</TargetPath>
     <!--We won't be generating debug symbols here -->
     <_DebugSymbolsProduced>false</_DebugSymbolsProduced>
     <CoreBuildDependsOn>

--- a/test/TestProject/TestProject.csproj
+++ b/test/TestProject/TestProject.csproj
@@ -8,7 +8,7 @@
     <AllowSnapshotIsolation>True</AllowSnapshotIsolation>
     <ReadCommittedSnapshot>True</ReadCommittedSnapshot>
     <ServiceBrokerOption>EnableBroker</ServiceBrokerOption>
-    <PackageProjectUrl>https://github.com/jmezach/MSBuild.Sdk.SqlProj/</PackageProjectUrl>    
+    <PackageProjectUrl>https://github.com/jmezach/MSBuild.Sdk.SqlProj/</PackageProjectUrl>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />


### PR DESCRIPTION
We should allow users to allow to specify a different name for the `.dacpac` file if they choose to do so. This could already be achieved by specifying `<AssemblyName>` in the `.csproj` but when specifying an alternative name it would break `dotnet publish` since it would still look for the `.dacpac` using the projects name. This has now been fixed.

While working on this I also discovered the `<TargetName>` property which can also be set to control the name of the output file, which probably makes a little bit more sense than setting '`<AssemblyName>'. I'll make sure to add that to the docs before completing this PR.

It is probably also worth noting that we currently expect the `.dacpac` to have the same name as the NuGet package when used as a '<PackageReference>`. I'll make sure that I add that to the documentation as well.

Fixes: #68 