### PR TITLE
Allow users to specify an explicit port for publishing (#97)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         dotnet-version: '3.1.x'
 
-    - name: Setup dotnet
+    - name: Setup dotnet 5.0
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-18.04", "macos-10.15", "windows-2019" ]
-        dotnet: [ '2.1.809', '3.1.401', '5.0.100-rc.1.20452.10' ]
+        dotnet: [ '2.1.x', '3.1.x', '5.0.x' ]
       fail-fast: false
 
     steps:
@@ -278,7 +278,7 @@ jobs:
     # Setup .NET SDK
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100-rc.1.20452.10'
+        dotnet-version: '5.0.x'
 
     # Install Nerdbank.GitVersioning
     - name: install nbgv
@@ -324,7 +324,7 @@ jobs:
     # Setup .NET SDK
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100-rc.1.20452.10'
+        dotnet-version: '5.0.x'
 
     # Download artifacts
     - name: download-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,7 +175,7 @@ jobs:
 
     # Build the project using double wildcard (i.e. 1.*-*)
     - name: build project (double floating version / dotnet 3)
-      if: ${{ matrix.dotnet != '2.1.809' }}
+      if: ${{ matrix.dotnet != '2.1.x' }}
       run: dotnet build ./test/TestProjectWithSDKRef/TestProjectWithSDKRef.csproj /bl /p:DependencyVersion="1.*-*" /warnaserror:SQL71502
       shell: pwsh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,21 @@ jobs:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         submodules: 'true' # need to check out the SqlTools submodule to build successfully.
 
-    # Install .NET Core SDK
-    # TOOO: Remove this workaround once https://github.com/actions/setup-dotnet/issues/25 gets fixed
-    - name: Setup .NET Core
-      uses: coderpatros/setup-dotnet@sxs
+    # Install .NET Core SDK's for 2.1, 3.1 and 5.0
+    - name: Setup dotnet 2.1
+      uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.1.809, 3.1.401, 5.0.100-rc.1.20452.10
+        dotnet-version: '2.1.x'
+
+    - name: Setup dotnet 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
 
     # Install Nerdbank.GitVersioning
     - name: install nbgv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,7 +181,7 @@ jobs:
 
     # Upload dacpac
     - name: upload
-      if: ${{ matrix.os == 'ubuntu-18.04' && matrix.dotnet == '3.1.401' }}
+      if: ${{ matrix.os == 'ubuntu-18.04' && matrix.dotnet == '3.1.x' }}
       uses: actions/upload-artifact@v1
       with:
         name: dacpac-package

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.2.31</Version>
+      <Version>3.3.37</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/DacpacTool/DeployOptions.cs
+++ b/src/DacpacTool/DeployOptions.cs
@@ -6,6 +6,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
     {
         public FileInfo Input { get; set; }
         public string TargetServerName { get; set; }
+        public string TargetPort { get; set; }
         public string TargetDatabaseName { get; set; }
         public string TargetUser { get; set; }
         public string TargetPassword { get; set; }

--- a/src/DacpacTool/DeployOptions.cs
+++ b/src/DacpacTool/DeployOptions.cs
@@ -6,7 +6,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
     {
         public FileInfo Input { get; set; }
         public string TargetServerName { get; set; }
-        public string TargetPort { get; set; }
+        public int? TargetPort { get; set; }
         public string TargetDatabaseName { get; set; }
         public string TargetUser { get; set; }
         public string TargetPassword { get; set; }

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -39,6 +39,14 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             ConnectionStringBuilder.DataSource = targetServer;
         }
 
+        public void UseTargetServerAndPort(string targetServer, int targetPort)
+        {
+            EnsurePackageLoaded();
+
+            _console.WriteLine($"Using target server '{targetServer}' on port {targetPort}");
+            ConnectionStringBuilder.DataSource = $"{targetServer},{targetPort}";
+        }
+
         public void UseSqlAuthentication(string username, string password)
         {
             EnsurePackageLoaded();

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -47,7 +47,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             {
                 new Option<FileInfo>(new string[] { "--input", "-i" }, "Path to the .dacpac package to deploy"),
                 new Option<string>(new string[] { "--targetServerName", "-tsn" }, "Name of the server to deploy the package to"),
-                new Option<string>(new string[] { "--targetPort", "-tprt" }, "Port number to connect on (leave blank for default)"),
+                new Option<int>(new string[] { "--targetPort", "-tprt" }, "Port number to connect on (leave blank for default)"),
                 new Option<string>(new string[] { "--targetDatabaseName", "-tdn" }, "Name of the database to deploy the package to"),
                 new Option<string>(new string[] { "--targetUser", "-tu" }, "Username used to connect to the target server, using SQL Server authentication"),
                 new Option<string>(new string[] { "--targetPassword", "-tp" }, "Password used to connect to the target server, using SQL Server authentication"),
@@ -198,9 +198,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     }
                 }
 
-                if (options.TargetPort != null && Int32.TryParse(options.TargetPort, out int targetPort))
+                if (options.TargetPort.HasValue)
                 {
-                    deployer.UseTargetServerAndPort(options.TargetServerName, targetPort);
+                    deployer.UseTargetServerAndPort(options.TargetServerName, options.TargetPort.Value);
                 }
                 else
                 {

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -47,6 +47,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             {
                 new Option<FileInfo>(new string[] { "--input", "-i" }, "Path to the .dacpac package to deploy"),
                 new Option<string>(new string[] { "--targetServerName", "-tsn" }, "Name of the server to deploy the package to"),
+                new Option<string>(new string[] { "--targetPort", "-tprt" }, "Port number to connect on (leave blank for default)"),
                 new Option<string>(new string[] { "--targetDatabaseName", "-tdn" }, "Name of the database to deploy the package to"),
                 new Option<string>(new string[] { "--targetUser", "-tu" }, "Username used to connect to the target server, using SQL Server authentication"),
                 new Option<string>(new string[] { "--targetPassword", "-tp" }, "Password used to connect to the target server, using SQL Server authentication"),
@@ -197,7 +198,14 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     }
                 }
 
-                deployer.UseTargetServer(options.TargetServerName);
+                if (options.TargetPort != null && Int32.TryParse(options.TargetPort, out int targetPort))
+                {
+                    deployer.UseTargetServerAndPort(options.TargetServerName, targetPort);
+                }
+                else
+                {
+                    deployer.UseTargetServer(options.TargetServerName);
+                }
                 
                 if (!string.IsNullOrWhiteSpace(options.TargetUser))
                 {

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -211,13 +211,14 @@
     <PropertyGroup>
       <InputArgument>-i &quot;$(TargetPath)&quot;</InputArgument>
       <TargetServerNameArgument>-tsn &quot;$(TargetServerName)&quot;</TargetServerNameArgument>
+      <TargetPortArgument Condition="'$(TargetPort)'!=''">-tprt &quot;$(TargetPort)&quot;</TargetPortArgument>
       <TargetDatabaseNameArgument>-tdn &quot;$(TargetDatabaseName)&quot;</TargetDatabaseNameArgument>
       <TargetUserArgument Condition="'$(TargetUser)'!=''">-tu &quot;$(TargetUser)&quot;</TargetUserArgument>
       <TargetPasswordArgument Condition="'$(TargetPassword)'!=''">-tp &quot;$(TargetPassword)&quot;</TargetPasswordArgument>
       <PropertyArguments>@(DeployPropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
       <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)=%(Value)', ' ')</SqlCmdVariableArguments>
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
-      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; deploy $(InputArgument) $(TargetServerNameArgument) $(TargetDatabaseNameArgument) $(TargetUserArgument) $(TargetPasswordArgument) $(PropertyArguments) $(SqlCmdVariableArguments) $(DebugArgument)</DacpacToolCommand>
+      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; deploy $(InputArgument) $(TargetServerNameArgument) $(TargetDatabaseNameArgument) $(TargetPortArgument) $(TargetUserArgument) $(TargetPasswordArgument) $(PropertyArguments) $(SqlCmdVariableArguments) $(DebugArgument)</DacpacToolCommand>
     </PropertyGroup>
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />
     <Exec Command="$(DacpacToolCommand)" />

--- a/test/DacpacTool.Tests/PackageDeployerTests.cs
+++ b/test/DacpacTool.Tests/PackageDeployerTests.cs
@@ -57,6 +57,22 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         }
 
         [TestMethod]
+        public void UseTargetServerAndPort()
+        {
+            // Arrange
+            using var packageDeployer = new PackageDeployer(_console);
+            var packagePath = BuildSimpleModel();
+
+            // Act
+            packageDeployer.LoadPackage(packagePath);
+            packageDeployer.UseTargetServerAndPort("localhost", 1432);
+
+            // Assert
+            packageDeployer.ConnectionStringBuilder.DataSource.ShouldNotBeNull();
+            packageDeployer.ConnectionStringBuilder.DataSource.ShouldBe("localhost,1432");
+        }
+
+        [TestMethod]
         public void UseTargetServerWithoutLoadPackage()
         {
             // Arrange


### PR DESCRIPTION
This PR creates a new `UseTargetServerAndPort` method, called only if the user passes in a port. If a port isn't specified, rather than using a default port of 1433, we just fall back to the existing method of not including the port in the connection string at all.