### PR TITLE
Allow running pre/post deployment scripts for referenced packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dotnet new sqlproj -s Sql130
 You should now have a project file with the following contents:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <SqlServerVersion>Sql130</SqlServerVersion>
@@ -89,7 +89,7 @@ If you already have a SSDT (.sqlproj) project in your solution, you can keep tha
 There are a lot of properties that can be set on the model in the resulting `.dacpac` file which can be influenced by setting those properties in the project file using the same name. For example, the snippet below sets the `RecoveryMode` property to `Simple`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <RecoveryMode>Simple</RecoveryMode>
@@ -108,7 +108,7 @@ Support for pre- and post deployment scripts has been added in version 1.1.0. Th
 To include these scripts into your `.dacpac` add the following to your `.csproj`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -120,11 +120,26 @@ To include these scripts into your `.dacpac` add the following to your `.csproj`
 </Project>
 ```
 
+By default the pre- and/or post-deployment script of referenced packages (both [PackageReference](#package-references) and [ProjectReference](#project-references)) are not run when using `dotnet publish`. As of version 1.11.0 this can be optionally enabled by adding a property `RunScriptsFromReferences` to the project file as in the below example:
+
+```xml
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+    <PropertyGroup>
+        <RunScriptsFromReferences>True</RunScriptFromReferences>
+        ...
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="MyDatabasePackage" Version="1.0.0" />
+    </ItemGroup>
+</Project>
+```
+
 ## SQLCMD variables
 Especially when using pre- and post deployment scripts, but also in other scenario's, it might be useful to define variables that can be controlled at deployment time. This is supported through the use of SQLCMD variables, added in version 1.1.0. These variables can be defined in your project file using the following syntax:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -146,7 +161,7 @@ Especially when using pre- and post deployment scripts, but also in other scenar
 `MSBuild.Sdk.SqlProj` supports referencing NuGet packages that contain `.dacpac` packages. These can be referenced by using the `PackageReference` format familiar to .NET developers. They can also be installed through the NuGet Package Manager in Visual Studio.
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -160,7 +175,7 @@ Especially when using pre- and post deployment scripts, but also in other scenar
 It will assume that the `.dacpac` file is inside the `tools` folder of the referenced package and that it has the same name as the NuGet package. Referenced packages that do not adhere to this convention will be silently ignored. By default the package reference is treated as being part of the same database. For example, if the reference package contains a `.dacpac` that has a table and a stored procedure and you would `dotnet publish` the project the table and stored procedure from that package will be deployed along with the contents of your project to the same database. If this is not desired, you can add the `DatabaseVariableLiteralValue` item metadata to the `PackageReference` specifying a different database name:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -190,7 +205,7 @@ sqlpackage
 Similar to package references you can also reference another project by using a `ProjectReference`. These references can be added manually to the project file or they can be added through Visual Studio. For example, consider the following example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -204,7 +219,7 @@ Similar to package references you can also reference another project by using a 
 This will ensure that `MyOtherProject` is built first and the resulting `.dacpac` will be referenced by this project. This means you can use the objects defined in the other project within the scope of this project. If the other project is representing an entirely different database you can also use `DatabaseVariableLiteralValue` attribute on the `ProjectReference` similar to `PackageReference`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -248,7 +263,7 @@ This will ensure that `MyOtherProject` is built first and the resulting `.dacpac
 Additionally you'll need to set the `PackageProjectUrl` property inside of the `.csproj` like this:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
   <PropertyGroup>
     ...
     <PackageProjectUrl>your-project-url</PackageProjectUrl>
@@ -319,7 +334,7 @@ To further customize the deployment process, you can use the following propertie
 In addition to these properties, you can also set any of the [documented](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacdeployoptions) deployment options. These are typically set in the project file, for example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.10.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
     <PropertyGroup>
         ...
         <BackupDatabaseBeforeChanges>True</BackupDatabaseBeforeChanges>

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Especially when using pre- and post deployment scripts, but also in other scenar
 </Project>
 ```
 
+> Note: In versions prior to 1.11.0 the `DefaultValue` element displayed above was not used. As of version 1.11.0 the value of `Value` is checked first and if it found to be empty we'll fall back to `DefaultValue`. 
+
 ## Package references
 `MSBuild.Sdk.SqlProj` supports referencing NuGet packages that contain `.dacpac` packages. These can be referenced by using the `PackageReference` format familiar to .NET developers. They can also be installed through the NuGet Package Manager in Visual Studio.
 

--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -25,10 +25,7 @@
     <EmbeddedResource Include="$(ManagedBatchParserPath)/Localization/sr.resx" LogicalName="Microsoft.SqlTools.ManagedBatchParser.Localization.SR.resources" />
     <None Include="$(ManagedBatchParserPath)/Localization/sr.strings" />
     <Compile Include="$(ManagedBatchParserPath)/BatchParser/**/*.cs" />
-    <Compile Remove="$(ManagedBatchParserPath)/BatchParser/ExecutionEngineCode/ExecutionEngine.cs" />
-    <Compile Remove="$(ManagedBatchParserPath)/BatchParser/ExecutionEngineCode/Batch.cs" />
-    <Compile Remove="$(ManagedBatchParserPath)/BatchParser/ExecutionEngineCode/BatchParser*Args.cs" />
-    <Compile Remove="$(ManagedBatchParserPath)/BatchParser/BatchParserWrapper.cs" />
+    <Compile Include="$(ManagedBatchParserPath)/ReliableConnection/**/*.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -12,14 +12,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.DACFX" Version="150.4826.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20427.1" />
-    <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
+    <PackageReference Include="Microsoft.SqlServer.DACFX" Version="150.4897.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.Security.Permissions" Version="5.0.0" />
   </ItemGroup>
 
   <!-- References to Microsoft.SqlTools.ManagedBatchParser -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.41011.9" />
+    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46041.41" />
     <ProjectReference Include="$(SqlToolsPath)/Microsoft.SqlTools.Hosting/Microsoft.SqlTools.Hosting.csproj" />
     <Compile Include="$(ManagedBatchParserPath)/Localization/*.cs" />
     <EmbeddedResource Include="$(ManagedBatchParserPath)/Localization/sr.resx" LogicalName="Microsoft.SqlTools.ManagedBatchParser.Localization.SR.resources" />

--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -14,7 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SqlServer.DACFX" Version="150.4897.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
-    <PackageReference Include="System.Security.Permissions" Version="5.0.0" />
   </ItemGroup>
 
   <!-- References to Microsoft.SqlTools.ManagedBatchParser -->

--- a/src/DacpacTool/DeployOptions.cs
+++ b/src/DacpacTool/DeployOptions.cs
@@ -12,5 +12,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public string TargetPassword { get; set; }
         public string[] Property { get; set; }
         public string[] SqlCmdVar { get; set; }
+        public bool RunScriptsFromReferences { get; set; }
     }
 }

--- a/src/DacpacTool/Extensions.cs
+++ b/src/DacpacTool/Extensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using Microsoft.SqlServer.Dac;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 
@@ -10,6 +11,30 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
     public static class Extensions
     {
+        public static string GetPreDeploymentScript(this DacPackage package)
+        {
+            var stream = package.PreDeploymentScript;
+            if (stream == null)
+            {
+                return null;
+            }
+
+            using var streamReader = new StreamReader(stream);
+            return streamReader.ReadToEnd();
+        }
+
+        public static string GetPostDeploymentScript(this DacPackage package)
+        {
+            var stream = package.PostDeploymentScript;
+            if (stream == null)
+            {
+                return null;
+            }
+
+            using var streamReader = new StreamReader(stream);
+            return streamReader.ReadToEnd();
+        }
+
         public static void AddReference(this TSqlModel model, string referencePath, string externalParts)
         {
             var dataSchemaModel = GetDataSchemaModel(model);

--- a/src/DacpacTool/Extensions.cs
+++ b/src/DacpacTool/Extensions.cs
@@ -47,8 +47,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             outputMessageBuilder.Append(args.Line);
             outputMessageBuilder.Append(',');
             outputMessageBuilder.Append(args.TextSpan.iStartIndex);
-            outputMessageBuilder.Append("):");
-            outputMessageBuilder.Append("error ");
+            outputMessageBuilder.Append("): ");
+            outputMessageBuilder.Append("error: ");
             
             if (args.Exception != null)
             {
@@ -63,8 +63,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             }
             else
             {
-                outputMessageBuilder.Append(args.MessageType);
-                outputMessageBuilder.Append(' ');
                 outputMessageBuilder.Append(args.Message);
                 outputMessageBuilder.Append(' ');
                 outputMessageBuilder.Append(args.Description);

--- a/src/DacpacTool/Extensions.cs
+++ b/src/DacpacTool/Extensions.cs
@@ -130,7 +130,10 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 }
 
                 var fileName = (string)getMetadataMethod.Invoke(reference, new object[] { "FileName" });
-                result.Add(fileName);
+                if (!string.IsNullOrEmpty(fileName))
+                {
+                    result.Add(fileName);
+                }
             }
 
             return result;

--- a/src/DacpacTool/Extensions.cs
+++ b/src/DacpacTool/Extensions.cs
@@ -3,14 +3,76 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.SqlServer.TransactSql.ScriptDom;
+using Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
     public static class Extensions
     {
+        public static string Format(this BatchErrorEventArgs args, string source)
+        {
+            var outputMessageBuilder = new StringBuilder();
+            outputMessageBuilder.Append(source);
+            outputMessageBuilder.Append('(');
+            outputMessageBuilder.Append(args.Line);
+            outputMessageBuilder.Append(',');
+            outputMessageBuilder.Append(args.TextSpan.iStartIndex);
+            outputMessageBuilder.Append("):");
+            outputMessageBuilder.Append("error ");
+            
+            if (args.Exception != null)
+            {
+                outputMessageBuilder.Append(args.Message);
+            }
+            else
+            {
+                outputMessageBuilder.Append("SQL");
+                outputMessageBuilder.Append(args.Error.Number);
+                outputMessageBuilder.Append(": ");
+                outputMessageBuilder.Append(args.Error.Message);
+            }
+            
+            return outputMessageBuilder.ToString();
+        }
+
+        public static string Format(this BatchParserExecutionErrorEventArgs args, string source)
+        {
+            var outputMessageBuilder = new StringBuilder();
+            outputMessageBuilder.Append(source);
+            outputMessageBuilder.Append('(');
+            outputMessageBuilder.Append(args.Line);
+            outputMessageBuilder.Append(',');
+            outputMessageBuilder.Append(args.TextSpan.iStartIndex);
+            outputMessageBuilder.Append("):");
+            outputMessageBuilder.Append("error ");
+            
+            if (args.Exception != null)
+            {
+                outputMessageBuilder.Append(args.Message);
+            }
+            else if (args.Error != null)
+            {
+                outputMessageBuilder.Append("SQL");
+                outputMessageBuilder.Append(args.Error.Number);
+                outputMessageBuilder.Append(": ");
+                outputMessageBuilder.Append(args.Error.Message);
+            }
+            else
+            {
+                outputMessageBuilder.Append(args.MessageType);
+                outputMessageBuilder.Append(' ');
+                outputMessageBuilder.Append(args.Message);
+                outputMessageBuilder.Append(' ');
+                outputMessageBuilder.Append(args.Description);
+            }
+            
+            return outputMessageBuilder.ToString();
+        }
+
         public static string GetPreDeploymentScript(this DacPackage package)
         {
             var stream = package.PreDeploymentScript;

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.IO;
+using System.IO.Packaging;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using Microsoft.Data.Tools.Schema.Sql.Packaging;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlServer.Dac.Model;
-using Microsoft.SqlTools.ServiceLayer.BatchParser;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -232,7 +232,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         {
             if (options.Debug)
             {
-                Console.WriteLine("Waiting for debugger to attach");
+                Console.WriteLine($"Waiting for debugger to attach ({System.Diagnostics.Process.GetCurrentProcess().Id})");
                 while (!Debugger.IsAttached)
                 {
                     Thread.Sleep(100);

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -145,9 +145,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         private static int InspectIncludes(InspectOptions options)
         {
-            // Wait for a debugger to attach
-            WaitForDebuggerToAttach(options);
-
             var scriptInspector = new ScriptInspector();
 
             // Add predeployment and postdeployment scripts

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -177,8 +177,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             try
             {
-                using var deployer = new PackageDeployer(new ActualConsole());
-                deployer.LoadPackage(options.Input);
+                var deployer = new PackageDeployer(new ActualConsole());
 
                 if (options.Property != null)
                 {
@@ -216,7 +215,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     deployer.UseWindowsAuthentication();
                 }
 
-                deployer.Deploy(options.TargetDatabaseName);
+                deployer.Deploy(options.Input, options.TargetDatabaseName);
                 return 0;
             }
             catch (ArgumentException ex)

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -53,6 +53,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<string>(new string[] { "--targetPassword", "-tp" }, "Password used to connect to the target server, using SQL Server authentication"),
                 new Option<string[]>(new string[] { "--property", "-p" }, "Properties used to control the deployment"),
                 new Option<string[]>(new string[] { "--sqlcmdvar", "-sc" }, "SqlCmdVariable(s) and their associated values, separated by an equals sign."),
+                new Option<bool>(new string[] { "--runScriptsFromReferences", "-sff" }, "Whether to run pre- and postdeployment scripts from references"),
 #if DEBUG
                 new Option<bool>(new string[] { "--debug" }, "Waits for a debugger to attach")
 #endif
@@ -212,7 +213,18 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     deployer.UseWindowsAuthentication();
                 }
 
+                if (options.RunScriptsFromReferences)
+                {
+                    deployer.RunPreDeploymentScriptFromReferences(options.Input, options.TargetDatabaseName);
+                }
+
                 deployer.Deploy(options.Input, options.TargetDatabaseName);
+
+                if (options.RunScriptsFromReferences)
+                {
+                    deployer.RunPostDeploymentScriptFromReferences(options.Input, options.TargetDatabaseName);
+                }
+
                 return 0;
             }
             catch (ArgumentException ex)

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -217,8 +217,9 @@
       <TargetPasswordArgument Condition="'$(TargetPassword)'!=''">-tp &quot;$(TargetPassword)&quot;</TargetPasswordArgument>
       <PropertyArguments>@(DeployPropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
       <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)=%(Value)', ' ')</SqlCmdVariableArguments>
+      <RunScriptsFromReferencesArgument Condition="'$(RunScriptsFromReferences)' == 'True'">-sff</RunScriptsFromReferencesArgument>
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
-      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; deploy $(InputArgument) $(TargetServerNameArgument) $(TargetDatabaseNameArgument) $(TargetPortArgument) $(TargetUserArgument) $(TargetPasswordArgument) $(PropertyArguments) $(SqlCmdVariableArguments) $(DebugArgument)</DacpacToolCommand>
+      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; deploy $(InputArgument) $(TargetServerNameArgument) $(TargetDatabaseNameArgument) $(TargetPortArgument) $(TargetUserArgument) $(TargetPasswordArgument) $(PropertyArguments) $(SqlCmdVariableArguments) $(RunScriptsFromReferencesArgument) $(DebugArgument)</DacpacToolCommand>
     </PropertyGroup>
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />
     <Exec Command="$(DacpacToolCommand)" />

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -207,6 +207,11 @@
       <DeployPropertyNames Include="@(_DeployPropertyNames)" Condition=" '$(%(Identity))' != '' ">
         <PropertyValue>$(%(_DeployPropertyNames.Identity))</PropertyValue>
       </DeployPropertyNames>
+      <!-- Resolve default values for SQLCMD variables -->
+      <_ResolvedSqlCmdVariable Include="@(SqlCmdVariable)">
+        <Value Condition="'%(SqlCmdVariable.Value)' != ''">%(SqlCmdVariable.Value)</Value>
+        <Value Condition="'%(SqlCmdVariable.Value)' == ''">%(SqlCmdVariable.DefaultValue)</Value>
+      </_ResolvedSqlCmdVariable>
     </ItemGroup>
     <PropertyGroup>
       <InputArgument>-i &quot;$(TargetPath)&quot;</InputArgument>
@@ -216,7 +221,7 @@
       <TargetUserArgument Condition="'$(TargetUser)'!=''">-tu &quot;$(TargetUser)&quot;</TargetUserArgument>
       <TargetPasswordArgument Condition="'$(TargetPassword)'!=''">-tp &quot;$(TargetPassword)&quot;</TargetPasswordArgument>
       <PropertyArguments>@(DeployPropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
-      <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)=%(Value)', ' ')</SqlCmdVariableArguments>
+      <SqlCmdVariableArguments>@(_ResolvedSqlCmdVariable->'-sc %(Identity)=%(Value)', ' ')</SqlCmdVariableArguments>
       <RunScriptsFromReferencesArgument Condition="'$(RunScriptsFromReferences)' == 'True'">-sff</RunScriptsFromReferencesArgument>
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
       <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; deploy $(InputArgument) $(TargetServerNameArgument) $(TargetDatabaseNameArgument) $(TargetPortArgument) $(TargetUserArgument) $(TargetPasswordArgument) $(PropertyArguments) $(SqlCmdVariableArguments) $(RunScriptsFromReferencesArgument) $(DebugArgument)</DacpacToolCommand>

--- a/test/DacpacTool.Tests/DacpacHeaderParser/DacpacXml.cs
+++ b/test/DacpacTool.Tests/DacpacHeaderParser/DacpacXml.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using Microsoft.Data.Tools.Schema.Sql.Packaging;
+using System.IO.Packaging;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests.DacpacHeaderParser
 {

--- a/test/DacpacTool.Tests/DacpacTool.Tests.csproj
+++ b/test/DacpacTool.Tests/DacpacTool.Tests.csproj
@@ -2,26 +2,23 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
-
     <IsPackable>false</IsPackable>
-
     <AssemblyName>MSBuild.Sdk.SqlProj.DacpacTool.Tests</AssemblyName>
-
     <RootNamespace>MSBuild.Sdk.SqlProj.DacpacTool.Tests</RootNamespace>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.13" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DacpacTool.Tests/DacpacTool.Tests.csproj
+++ b/test/DacpacTool.Tests/DacpacTool.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/test/DacpacTool.Tests/ExtensionsTest.cs
+++ b/test/DacpacTool.Tests/ExtensionsTest.cs
@@ -33,6 +33,28 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         }
 
         /// <summary>
+        /// Tests that we can get references from a model.
+        /// </summary>
+        [TestMethod]
+        public void CanGetReferences()
+        {
+            // Arrange
+            var referencePackage = new TestModelBuilder()
+                .AddTable("MyTable", ("Column1", "nvarchar(100)"))
+                .SaveAsPackage();
+            var model = new TestModelBuilder()
+                .AddReference(referencePackage)
+                .Build();
+            
+            // Act
+            var references = model.GetReferencedDacPackages();
+
+            // Assert
+            references.Any().ShouldBeTrue();
+            references.First().ShouldBe(referencePackage);
+        }
+
+        /// <summary>
         /// Tests that we can get model validation errors from a model.
         /// </summary>
         [TestMethod]

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Packaging;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Data.Tools.Schema.Sql.Packaging;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlServer.Dac.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/DacpacTool.Tests/PackageDeployerTests.cs
+++ b/test/DacpacTool.Tests/PackageDeployerTests.cs
@@ -10,45 +10,15 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
     [TestClass]
     public class PackageDeployerTests
     {
-        private IConsole _console = Substitute.For<IConsole>();
-
-        [TestMethod]
-        public void LoadPackage()
-        {
-            // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
-
-            // Act
-            packageDeployer.LoadPackage(packagePath);
-
-            // Assert
-            packageDeployer.Package.ShouldNotBeNull();
-        }
-
-        [TestMethod]
-        public void LoadPackageFileDoesNotExist()
-        {
-            // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = "SomeDummyFile.dacpac";
-
-            // Act
-            Should.Throw<ArgumentException>(() => packageDeployer.LoadPackage(new FileInfo(packagePath)));
-
-            // Assert
-            packageDeployer.Package.ShouldBeNull();
-        }
+        private readonly IConsole _console = Substitute.For<IConsole>();
 
         [TestMethod]
         public void UseTargetServer()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.UseTargetServer("localhost");
 
             // Assert
@@ -60,11 +30,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void UseTargetServerAndPort()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.UseTargetServerAndPort("localhost", 1432);
 
             // Assert
@@ -73,28 +41,12 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         }
 
         [TestMethod]
-        public void UseTargetServerWithoutLoadPackage()
-        {
-            // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
-
-            // Act
-            Should.Throw<InvalidOperationException>(() => packageDeployer.UseTargetServer("localhost"));
-
-            // Assert
-            packageDeployer.ConnectionStringBuilder.DataSource.ShouldBeEmpty();
-        }
-
-        [TestMethod]
         public void UseWindowsAuthentication()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.UseWindowsAuthentication();
 
             // Assert
@@ -102,28 +54,12 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         }
 
         [TestMethod]
-        public void UseWindowsAuthenticationWithoutLoadPackage()
-        {
-            // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
-
-            // Act
-            Should.Throw<InvalidOperationException>(() => packageDeployer.UseWindowsAuthentication());
-
-            // Assert
-            packageDeployer.ConnectionStringBuilder.IntegratedSecurity.ShouldBeFalse();
-        }
-
-        [TestMethod]
         public void UseSqlServerAuthenticationNoPasswordPrompts()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.UseSqlAuthentication("testuser", null);
 
             // Assert
@@ -137,11 +73,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         {
             // Arrange
             _console.ReadLine().Returns("testpassword");
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.UseSqlAuthentication("testuser", null);
 
             // Assert
@@ -154,11 +88,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void UseSqlAuthenticationWithPasswordDoesNotPrompt()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.UseSqlAuthentication("testuser", "testpassword");
 
             // Assert
@@ -172,11 +104,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetSqlCmdVariable()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.SetSqlCmdVariable("MySqlCmdVariable", "SomeValue");
 
             // Assert
@@ -188,11 +118,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetSqlCmdVariableNoValue()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             Should.Throw<ArgumentException>(() => packageDeployer.SetSqlCmdVariable("MySqlCmdVariable", string.Empty));
 
             // Assert
@@ -200,40 +128,35 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         }
 
         [TestMethod]
-        public void DeployNoPackageLoaded()
-        {
-            // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
-
-            // Act
-            Should.Throw<InvalidOperationException>(() => packageDeployer.Deploy("TestDatabase"));
-
-            // Assert
-            // Should throw
-        }
-
-        [TestMethod]
         public void DeployNoAuthentication()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
+            var packageDeployer = new PackageDeployer(_console);
             var packagePath = BuildSimpleModel();
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
-            Should.Throw<InvalidOperationException>(() => packageDeployer.Deploy("TestDatabase"));
+            Should.Throw<InvalidOperationException>(() => packageDeployer.Deploy(packagePath, "TestDatabase"));
+        }
+
+        [TestMethod]
+        public void DeployPackageDoesNotExist()
+        {
+            // Arrange
+            var packageDeployer = new PackageDeployer(_console);
+            packageDeployer.UseTargetServer("localhost");
+            packageDeployer.UseWindowsAuthentication();
+
+            // Act
+            Should.Throw<ArgumentException>(() => packageDeployer.Deploy(new FileInfo("does-not-exist.dacpac"), "TestDatabase"));
         }
 
         [TestMethod]
         public void SetPropertySimpleValue()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.SetProperty("AllowDropBlockingAssemblies", "true");
 
             // Assert
@@ -244,11 +167,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetPropertyInvalidFormat()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             Should.Throw<ArgumentException>(() => packageDeployer.SetProperty("AllowDropBlockingAssemblies", "ARandomString"));
         }
 
@@ -256,11 +177,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetPropertyDoNotDropObjectTypes()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.SetProperty("DoNotDropObjectTypes", "Aggregates;Assemblies");
 
             // Assert
@@ -271,11 +190,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetPropertyExcludeObjectTypes()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.SetProperty("ExcludeObjectTypes", "Contracts;Endpoints");
 
             // Assert
@@ -286,11 +203,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetPropertyDatabaseSpecification()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             packageDeployer.SetProperty("DatabaseSpecification", "Hyperscale;1024;P15");
 
             // Assert
@@ -303,11 +218,10 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetPropertyDatabaseSpecificationInvalidEdition()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
+            var packageDeployer = new PackageDeployer(_console);
             var packagePath = BuildSimpleModel();
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             Should.Throw<ArgumentException>(() => packageDeployer.SetProperty("DatabaseSpecification", "MyFancyEdition;1024;P15"));
 
             // Assert
@@ -320,11 +234,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetPropertyDatabaseSpecificationInvalidMaximumSize()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             Should.Throw<ArgumentException>(() => packageDeployer.SetProperty("DatabaseSpecification", "hyperscale;NotAnInteger;P15"));
 
             // Assert
@@ -337,11 +249,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void SetPropertyDatabaseSpecificationTooFewParameters()
         {
             // Arrange
-            using var packageDeployer = new PackageDeployer(_console);
-            var packagePath = BuildSimpleModel();
+            var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.LoadPackage(packagePath);
             Should.Throw<ArgumentException>(() => packageDeployer.SetProperty("DatabaseSpecification", "hyperscale"));
 
             // Assert
@@ -350,7 +260,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             packageDeployer.DeployOptions.DatabaseSpecification.ServiceObjective.ShouldBeNull();
         }
 
-        private FileInfo BuildSimpleModel()
+        private static FileInfo BuildSimpleModel()
         {
             var packagePath = new TestModelBuilder()
                 .AddTable("TestTable", ("Column1", "nvarchar(100)"))

--- a/test/TestProjectWithPrePost/Post-Deployment/Script.PostDeployment.sql
+++ b/test/TestProjectWithPrePost/Post-Deployment/Script.PostDeployment.sql
@@ -10,6 +10,8 @@ Post-Deployment Script Template
 --------------------------------------------------------------------------------------
 */
 
+INSERT INTO [dbo].[MyTable] VALUES ('SomeString', 1)
+
 if SERVERPROPERTY('EngineEdition') > 4
 begin
 

--- a/test/TestProjectWithPrePost/Post-Deployment/Script.PostDeployment.sql
+++ b/test/TestProjectWithPrePost/Post-Deployment/Script.PostDeployment.sql
@@ -10,8 +10,10 @@ Post-Deployment Script Template
 --------------------------------------------------------------------------------------
 */
 
+PRINT 'Inserting record into MyTable'
 INSERT INTO [dbo].[MyTable] VALUES ('SomeString', 1)
 
+/*
 if SERVERPROPERTY('EngineEdition') > 4
 begin
 
@@ -43,3 +45,4 @@ begin
     END
 
 end
+*/

--- a/test/TestProjectWithPrePost/Post-Deployment/Script.PostDeployment.sql
+++ b/test/TestProjectWithPrePost/Post-Deployment/Script.PostDeployment.sql
@@ -13,7 +13,6 @@ Post-Deployment Script Template
 PRINT 'Inserting record into MyTable'
 INSERT INTO [dbo].[MyTable] VALUES ('SomeString', 1)
 
-/*
 if SERVERPROPERTY('EngineEdition') > 4
 begin
 
@@ -45,4 +44,3 @@ begin
     END
 
 end
-*/

--- a/test/TestProjectWithPrePost/TestProjectWithPrePost.csproj
+++ b/test/TestProjectWithPrePost/TestProjectWithPrePost.csproj
@@ -8,7 +8,7 @@
     <AllowSnapshotIsolation>True</AllowSnapshotIsolation>
     <ReadCommittedSnapshot>True</ReadCommittedSnapshot>
     <ServiceBrokerOption>EnableBroker</ServiceBrokerOption>
-    <PackageProjectUrl>https://github.com/jmezach/MSBuild.Sdk.SqlProj/</PackageProjectUrl>    
+    <PackageProjectUrl>https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/</PackageProjectUrl>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestProjectWithPrePostDependency/TestProjectWithPrePostDependency.csproj
+++ b/test/TestProjectWithPrePostDependency/TestProjectWithPrePostDependency.csproj
@@ -1,0 +1,14 @@
+<Project>
+    <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <SqlServerVersion>Sql150</SqlServerVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../TestProjectWithPrePost/TestProjectWithPrePost.csproj" />
+    </ItemGroup>
+
+    <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+</Project>

--- a/test/TestProjectWithPrePostDependency/TestProjectWithPrePostDependency.csproj
+++ b/test/TestProjectWithPrePostDependency/TestProjectWithPrePostDependency.csproj
@@ -11,5 +11,18 @@
         <ProjectReference Include="../TestProjectWithPrePost/TestProjectWithPrePost.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <!--
+        <SqlCmdVariable Include="DbUserPassword">
+            <DefaultValue>dbuser-password</DefaultValue>
+            <Value>$(SqlCmdVar__1)</Value>
+        </SqlCmdVariable>
+        <SqlCmdVariable Include="DbReaderPassword">
+            <DefaultValue>dbreader-password</DefaultValue>
+            <Value>$(SqlCmdVar__2)</Value>
+        </SqlCmdVariable>
+        -->
+    </ItemGroup>
+
     <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
 </Project>

--- a/test/TestProjectWithPrePostDependency/TestProjectWithPrePostDependency.csproj
+++ b/test/TestProjectWithPrePostDependency/TestProjectWithPrePostDependency.csproj
@@ -4,6 +4,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <SqlServerVersion>Sql150</SqlServerVersion>
+        <RunScriptsFromReferences>True</RunScriptsFromReferences>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/TestProjectWithPrePostDependency/TestProjectWithPrePostDependency.csproj
+++ b/test/TestProjectWithPrePostDependency/TestProjectWithPrePostDependency.csproj
@@ -12,16 +12,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!--
         <SqlCmdVariable Include="DbUserPassword">
             <DefaultValue>dbuser-password</DefaultValue>
-            <Value>$(SqlCmdVar__1)</Value>
+            <Value>$(DbUserPassword)</Value>
         </SqlCmdVariable>
         <SqlCmdVariable Include="DbReaderPassword">
             <DefaultValue>dbreader-password</DefaultValue>
-            <Value>$(SqlCmdVar__2)</Value>
+            <Value>$(DbReaderPassword)</Value>
         </SqlCmdVariable>
-        -->
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />


### PR DESCRIPTION
When referencing other database packages, either by using a `ProjectReference` or a `PackageReference`, the pre- and/or post-deployment scripts of those dependencies are not run during deployment. While this is understandable in a deployment pipeline when using `SqlPackage.exe` it can be desirable when developers need to update their local development databases. For example, when the post-deployment script inserts some well-known data into certain tables, a developer might expect to have that data in his local development database. In this PR I've added opt-in support to allow for this.

Fixes #110 