### PR TITLE
Use comma separation for complex deploy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,9 @@ Most of those properties are simple values (like booleans, strings and integers)
 
 | Property | Example value | Description |
 | --- | --- | --- |
-| DatabaseSpecification | Hyperscale;1024;P15 | This property is specified in the format [Edition](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazureedition);[Maximum Size](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazuredatabasespecification.maximumsize);[Service Objective](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazuredatabasespecification.serviceobjective) |
-| DoNotDropObjectTypes | Aggregates;Assemblies | A semi-colon separated list of [Object Types](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.objecttype) that should not be dropped as part of the deployment |
-| ExcludeObjectTypes | Contracts;Endpoints | A semi-colon separated list of [Object Types](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.objecttype) that should not be part of the deployment |
+| DatabaseSpecification | Hyperscale;1024;P15 | This property is specified in the format [Edition](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazureedition),[Maximum Size](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazuredatabasespecification.maximumsize),[Service Objective](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazuredatabasespecification.serviceobjective) |
+| DoNotDropObjectTypes | Aggregates;Assemblies | A comma separated list of [Object Types](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.objecttype) that should not be dropped as part of the deployment |
+| ExcludeObjectTypes | Contracts;Endpoints | A comma separated list of [Object Types](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.objecttype) that should not be part of the deployment |
 | SqlCommandVariableValues | | These should not be set as a Property, but instead as an ItemGroup as described [here](#SQLCMD-Variables)
 
 ## Workaround for parser errors (SQL46010)

--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ You can now reference your dacpac as a `PackageReference`!
 > Note: To run these commands, you'll need to have the NuGet CLI tools installed. See [these installation instructions](https://docs.microsoft.com/nuget/install-nuget-client-tools#nugetexe-cli). If you use Chocolatey, you can also install by running `choco install nuget.commandline`. On a Mac with Homebrew installed, use `brew install nuget`.
 
 ## Publishing support
-Starting with version 1.2.0 of MSBuild.Sdk.SqlProj there is support for publishing a project to a SQL Server using the `dotnet publish` command. There are a couple of properties that control the deployment process which have some defaults to make the experience as smooth as possible for local development. For example, on Windows if you have a default SQL Server instance running on your local machine running `dotnet publish` creates a database with the same name as the project. Unfortunately on Mac and Linux we cannot use Windows authentication, so you'll need to specify a username and password:
+Starting with version 1.2.0 of MSBuild.Sdk.SqlProj there is support for publishing a project to a SQL Server using the `dotnet publish` command. This support is designed to be used by developers to deploy or update their local development database quickly. For more advanced deployment scenario's we suggest using [SqlPackage.exe](https://docs.microsoft.com/en-us/sql/tools/sqlpackage/sqlpackage?view=sql-server-ver15) instead as it provides more options.
+
+There are a couple of properties that control the deployment process which have some defaults to make the experience as smooth as possible for local development. For example, on Windows if you have a default SQL Server instance running on your local machine running `dotnet publish` creates a database with the same name as the project. Unfortunately on Mac and Linux we cannot use Windows authentication, so you'll need to specify a username and password:
 
 ```
 dotnet publish /p:TargetUser=<username> /p:TargetPassword=<password>

--- a/README.md
+++ b/README.md
@@ -350,9 +350,9 @@ Most of those properties are simple values (like booleans, strings and integers)
 
 | Property | Example value | Description |
 | --- | --- | --- |
-| DatabaseSpecification | Hyperscale;1024;P15 | This property is specified in the format [Edition](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazureedition),[Maximum Size](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazuredatabasespecification.maximumsize),[Service Objective](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazuredatabasespecification.serviceobjective) |
-| DoNotDropObjectTypes | Aggregates;Assemblies | A comma separated list of [Object Types](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.objecttype) that should not be dropped as part of the deployment |
-| ExcludeObjectTypes | Contracts;Endpoints | A comma separated list of [Object Types](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.objecttype) that should not be part of the deployment |
+| DatabaseSpecification | Hyperscale,1024,P15 | This property is specified in the format [Edition](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazureedition),[Maximum Size](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazuredatabasespecification.maximumsize),[Service Objective](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacazuredatabasespecification.serviceobjective) |
+| DoNotDropObjectTypes | Aggregates,Assemblies | A comma separated list of [Object Types](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.objecttype) that should not be dropped as part of the deployment |
+| ExcludeObjectTypes | Contracts,Endpoints | A comma separated list of [Object Types](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.objecttype) that should not be part of the deployment |
 | SqlCommandVariableValues | | These should not be set as a Property, but instead as an ItemGroup as described [here](#SQLCMD-Variables)
 
 ## Workaround for parser errors (SQL46010)

--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -292,7 +292,14 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 PropertyInfo property = typeof(DacDeployOptions).GetProperty(key, BindingFlags.Public | BindingFlags.Instance);
                 property.SetValue(DeployOptions, propertyValue);
 
-                _console.WriteLine($"Setting property {key} to value {value}");
+                var parsedValue = propertyValue switch
+                {
+                    ObjectType[] o => string.Join(',', o),
+                    DacAzureDatabaseSpecification s => $"{s.Edition},{s.MaximumSize},{s.ServiceObjective}",
+                    _ => propertyValue.ToString()
+                };
+
+                _console.WriteLine($"Setting property {key} to value {parsedValue}");
             }
             catch (FormatException)
             {
@@ -315,7 +322,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         private ObjectType[] ParseObjectTypes(string value)
         {
-            var objectTypes = value.Split(';');
+            var objectTypes = value.Split(',');
             var result = new ObjectType[objectTypes.Length];
 
             for (int i = 0; i < objectTypes.Length; i++)
@@ -333,7 +340,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         private DacAzureDatabaseSpecification ParseDatabaseSpecification(string value)
         {
-            var specification = value.Split(";", 3);
+            var specification = value.Split(",", 3);
             if (specification.Length != 3)
             {
                 throw new ArgumentException("Expected at least 3 parameters for DatabaseSpecification; Edition, MaximumSize and ServiceObjective", nameof(value));

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -322,7 +322,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         private ObjectType[] ParseObjectTypes(string value)
         {
-            if (value.Contains(';'))
+            if (value.Contains(';', StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException("Expected object types to be comma-seperated instead of semi-colon separated");
             }
@@ -345,7 +345,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         private DacAzureDatabaseSpecification ParseDatabaseSpecification(string value)
         {
-            if (value.Contains(';'))
+            if (value.Contains(';', StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException("Expected database specification to be comma-seperated instead of semi-colon separated");
             }

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -322,6 +322,11 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         private ObjectType[] ParseObjectTypes(string value)
         {
+            if (value.Contains(';'))
+            {
+                throw new ArgumentException("Expected object types to be comma-seperated instead of semi-colon separated");
+            }
+
             var objectTypes = value.Split(',');
             var result = new ObjectType[objectTypes.Length];
 
@@ -340,6 +345,11 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         private DacAzureDatabaseSpecification ParseDatabaseSpecification(string value)
         {
+            if (value.Contains(';'))
+            {
+                throw new ArgumentException("Expected database specification to be comma-seperated instead of semi-colon separated");
+            }
+
             var specification = value.Split(",", 3);
             if (specification.Length != 3)
             {

--- a/test/DacpacTool.Tests/PackageDeployerTests.cs
+++ b/test/DacpacTool.Tests/PackageDeployerTests.cs
@@ -180,7 +180,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.SetProperty("DoNotDropObjectTypes", "Aggregates;Assemblies");
+            packageDeployer.SetProperty("DoNotDropObjectTypes", "Aggregates,Assemblies");
 
             // Assert
             packageDeployer.DeployOptions.DoNotDropObjectTypes.ShouldBe(new ObjectType[] { ObjectType.Aggregates, ObjectType.Assemblies });
@@ -193,7 +193,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.SetProperty("ExcludeObjectTypes", "Contracts;Endpoints");
+            packageDeployer.SetProperty("ExcludeObjectTypes", "Contracts,Endpoints");
 
             // Assert
             packageDeployer.DeployOptions.ExcludeObjectTypes.ShouldBe(new ObjectType[] { ObjectType.Contracts, ObjectType.Endpoints });
@@ -206,7 +206,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.SetProperty("DatabaseSpecification", "Hyperscale;1024;P15");
+            packageDeployer.SetProperty("DatabaseSpecification", "Hyperscale,1024,P15");
 
             // Assert
             packageDeployer.DeployOptions.DatabaseSpecification.Edition.ShouldBe(DacAzureEdition.Hyperscale);

--- a/test/TestProject/TestProject.csproj
+++ b/test/TestProject/TestProject.csproj
@@ -11,5 +11,9 @@
     <PackageProjectUrl>https://github.com/jmezach/MSBuild.Sdk.SqlProj/</PackageProjectUrl>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <ExcludeObjectTypes>Users,Assemblies</ExcludeObjectTypes>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
 </Project>


### PR DESCRIPTION
Due to how semi-colons are parsed by shells the previous implementation using a semi-colon separated list of values doesn't actually work. I've now changed this to be comma separated instead. As discussed in #104 this is technically a breaking change, but since the old implementation didn't work either I don't think we have to sweat it.

I've also added the clarification discussed in #103 about `dotnet publish` support being targetted at developers updating their local databases and we suggest using SqlPackage.exe for more advanced scenario's .

Fixes #104 
Fixes #103 