### PR TITLE
Exclude scripts from bin/ and obj/ directories, add additional test case per discussion on #114

### DIFF
--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
@@ -37,11 +37,13 @@
   <Target Name="CompileDesignTime" />
 
   <ItemGroup>
-    <Content Include="**\*.sql">
+    <Content Include="**/*.sql">
       <Pack>False</Pack>
     </Content>
-    <Content Remove="Pre-Deployment\**\*.sql" />
-    <Content Remove="Post-Deployment\**\*.sql" />
+    <Content Remove="Pre-Deployment/**/*.sql" />
+    <Content Remove="Post-Deployment/**/*.sql" />
+    <Content Remove="bin/**/*.sql" />
+    <Content Remove="obj/**/*.sql" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/DacpacTool.Tests/ScriptParserTests.cs
+++ b/test/DacpacTool.Tests/ScriptParserTests.cs
@@ -62,6 +62,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             // Assert
             result.ShouldNotBeNull();
             result.Count().ShouldBe(2);
+            result.ToList().Take(2).Last().ShouldBe($"{TEST_PROJECT_PATH}/Pre-Deployment/./MoreScripts/Script2.sql");
         }
 
         [TestMethod]


### PR DESCRIPTION
Nothing major here -- just a few quick things that came up in the discussion of #114:
1. Edited Sdk.props to use forward-slashes instead of backslashes
2. Edited Sdk.props to exclude content from `bin/` and `obj`
3. Added an additional test to `ScriptParserTests.cs` to double-check the issue reported in #114, and decided that since I had already added it, I may as well keep it in there