### PR TITLE
Explicitly remove .dacpacs from assemblyreferences

### DIFF
--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -136,6 +136,18 @@
   </Target>
 
   <!--
+    Removes any referenced .dacpac from the _ResolvedProjectReferencePaths items to ensure that the .dacpac
+    isn't passed to the ResolveAssemblyReferences target since that would treat it as a .NET assembly.
+  -->
+  <Target Name="RemoveDatabaseReferencesFromAssemblyReferences"
+          DependsOnTargets="ResolveDatabaseReferences"
+          AfterTargets="ResolveProjectReferences">
+    <ItemGroup>
+      <_ResolvedProjectReferencePaths Remove="%(DacpacReference.Identity)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
     Gets a list of included files in the pre- and post-deploy scripts to include in the incremental build Inputs
   -->
   <Target Name="GetIncludedFiles" DependsOnTargets="ValidateEnvironment">


### PR DESCRIPTION
As discussed in #123 it appears that the `.dacpac` from a `ProjectReference` is passed to the `ResolveAssemblyReferences` target which sometimes fails, apparently due to the size of the `.dacpac`. Since that target treats the file as a .NET assembly it doesn't really make sense to process it through that target at all. So now we're explicitly removing any referenced `.dacpac` from the `_ResolvedProjectReferencePaths` item so it isn't processed by the `ResolveAssemblyReferences` target. Note that the reference is still being used to compile the `.dacpac` so that project references still work as before.

Fixes #123 