### PR TITLE
Adding support for TreatTSqlWarningsAsErrors and SuppressTSqlWarnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,32 @@ Refer to the [documentation](https://docs.microsoft.com/dotnet/api/microsoft.sql
 
 **Note:** If you are replacing an existing `.sqlproj` be sure to copy over any of these properties into the new project file.
 
+## Model compiler options
+Like an `.sqlproj` projects  `MSBuild.Sdk.SqlProj` supports special `msbuild` options how to process T-SQL compiling warnings.
+Treating warnings as errors can be optionally enabled by adding a property `TreatTSqlWarningsAsErrors` to the project file as in the below example:
+
+```xml
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+    <PropertyGroup>
+        <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
+        ...
+    </PropertyGroup>
+</Project>
+```
+
+Suppression of some warnings from treating as errors can be done by adding comma-separated (or semicolon) list of warning codes to `SuppressTSqlWarnings` property in the project file:
+
+```xml
+<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+    <PropertyGroup>
+        <SuppressTSqlWarnings>71558,71502</SuppressTSqlWarnings>
+        <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
+        ...
+    </PropertyGroup>
+</Project>
+```
+
+
 ## Pre- and post deployment scripts
 Support for pre- and post deployment scripts has been added in version 1.1.0. These scripts will be automatically executed when deploying the `.dacpac` to SQL Server.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you already have a SSDT (.sqlproj) project in your solution, you can keep tha
 There are a lot of properties that can be set on the model in the resulting `.dacpac` file which can be influenced by setting those properties in the project file using the same name. For example, the snippet below sets the `RecoveryMode` property to `Simple`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <RecoveryMode>Simple</RecoveryMode>
@@ -106,22 +106,23 @@ Refer to the [documentation](https://docs.microsoft.com/dotnet/api/microsoft.sql
 **Note:** If you are replacing an existing `.sqlproj` be sure to copy over any of these properties into the new project file.
 
 ## Model compiler options
-Like `.sqlproj` projects  `MSBuild.Sdk.SqlProj` supports controlling T-SQL build errors and warnings by using MSBuild properties..
+Like `.sqlproj` projects  `MSBuild.Sdk.SqlProj` supports controlling T-SQL build errors and warnings by using MSBuild properties.
 Treating warnings as errors can be optionally enabled by adding a property `TreatTSqlWarningsAsErrors` to the project file:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
         ...
     </PropertyGroup>
 </Project>
 ```
+> Note: Alternatively one can use `TreatWarningsAsErrors` instead of `TreatTSqlWarningsAsErrors` to apply the same effect.
 
 To suppress specific warnings from being treated as errors, add a comma-separated list of warning codes to `SuppressTSqlWarnings` property in the project file:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <SuppressTSqlWarnings>71558,71502</SuppressTSqlWarnings>
         <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
@@ -136,7 +137,7 @@ Support for pre- and post deployment scripts has been added in version 1.1.0. Th
 To include these scripts into your `.dacpac` add the following to your `.csproj`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -151,7 +152,7 @@ To include these scripts into your `.dacpac` add the following to your `.csproj`
 By default the pre- and/or post-deployment script of referenced packages (both [PackageReference](#package-references) and [ProjectReference](#project-references)) are not run when using `dotnet publish`. As of version 1.11.0 this can be optionally enabled by adding a property `RunScriptsFromReferences` to the project file as in the below example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <RunScriptsFromReferences>True</RunScriptFromReferences>
         ...
@@ -167,7 +168,7 @@ By default the pre- and/or post-deployment script of referenced packages (both [
 Especially when using pre- and post deployment scripts, but also in other scenario's, it might be useful to define variables that can be controlled at deployment time. This is supported through the use of SQLCMD variables, added in version 1.1.0. These variables can be defined in your project file using the following syntax:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -191,7 +192,7 @@ Especially when using pre- and post deployment scripts, but also in other scenar
 `MSBuild.Sdk.SqlProj` supports referencing NuGet packages that contain `.dacpac` packages. These can be referenced by using the `PackageReference` format familiar to .NET developers. They can also be installed through the NuGet Package Manager in Visual Studio.
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -205,7 +206,7 @@ Especially when using pre- and post deployment scripts, but also in other scenar
 It will assume that the `.dacpac` file is inside the `tools` folder of the referenced package and that it has the same name as the NuGet package. Referenced packages that do not adhere to this convention will be silently ignored. By default the package reference is treated as being part of the same database. For example, if the reference package contains a `.dacpac` that has a table and a stored procedure and you would `dotnet publish` the project the table and stored procedure from that package will be deployed along with the contents of your project to the same database. If this is not desired, you can add the `DatabaseVariableLiteralValue` item metadata to the `PackageReference` specifying a different database name:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -235,7 +236,7 @@ sqlpackage
 Similar to package references you can also reference another project by using a `ProjectReference`. These references can be added manually to the project file or they can be added through Visual Studio. For example, consider the following example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -249,7 +250,7 @@ Similar to package references you can also reference another project by using a 
 This will ensure that `MyOtherProject` is built first and the resulting `.dacpac` will be referenced by this project. This means you can use the objects defined in the other project within the scope of this project. If the other project is representing an entirely different database you can also use `DatabaseVariableLiteralValue` attribute on the `ProjectReference` similar to `PackageReference`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -293,7 +294,7 @@ This will ensure that `MyOtherProject` is built first and the resulting `.dacpac
 Additionally you'll need to set the `PackageProjectUrl` property inside of the `.csproj` like this:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
   <PropertyGroup>
     ...
     <PackageProjectUrl>your-project-url</PackageProjectUrl>
@@ -366,7 +367,7 @@ To further customize the deployment process, you can use the following propertie
 In addition to these properties, you can also set any of the [documented](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacdeployoptions) deployment options. These are typically set in the project file, for example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         ...
         <BackupDatabaseBeforeChanges>True</BackupDatabaseBeforeChanges>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dotnet new sqlproj -s Sql130
 You should now have a project file with the following contents:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/1.12.0">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <SqlServerVersion>Sql130</SqlServerVersion>
@@ -106,7 +106,7 @@ Refer to the [documentation](https://docs.microsoft.com/dotnet/api/microsoft.sql
 **Note:** If you are replacing an existing `.sqlproj` be sure to copy over any of these properties into the new project file.
 
 ## Model compiler options
-Like `.sqlproj` projects  `MSBuild.Sdk.SqlProj` supports special `msbuild` options to control T-SQL build errors and warning.
+Like `.sqlproj` projects  `MSBuild.Sdk.SqlProj` supports controlling T-SQL build errors and warnings by using MSBuild properties..
 Treating warnings as errors can be optionally enabled by adding a property `TreatTSqlWarningsAsErrors` to the project file:
 
 ```xml
@@ -118,7 +118,7 @@ Treating warnings as errors can be optionally enabled by adding a property `Trea
 </Project>
 ```
 
-To supress specific warnings from being treated as errors, add a comma-separated list of warning codes to `SuppressTSqlWarnings` property in the project file:
+To suppress specific warnings from being treated as errors, add a comma-separated list of warning codes to `SuppressTSqlWarnings` property in the project file:
 
 ```xml
 <Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Refer to the [documentation](https://docs.microsoft.com/dotnet/api/microsoft.sql
 **Note:** If you are replacing an existing `.sqlproj` be sure to copy over any of these properties into the new project file.
 
 ## Model compiler options
-Like an `.sqlproj` projects  `MSBuild.Sdk.SqlProj` supports special `msbuild` options how to process T-SQL compiling warnings.
-Treating warnings as errors can be optionally enabled by adding a property `TreatTSqlWarningsAsErrors` to the project file as in the below example:
+Like `.sqlproj` projects  `MSBuild.Sdk.SqlProj` supports special `msbuild` options to control T-SQL build errors and warning.
+Treating warnings as errors can be optionally enabled by adding a property `TreatTSqlWarningsAsErrors` to the project file:
 
 ```xml
 <Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
@@ -118,7 +118,7 @@ Treating warnings as errors can be optionally enabled by adding a property `Trea
 </Project>
 ```
 
-Suppression of some warnings from treating as errors can be done by adding comma-separated (or semicolon) list of warning codes to `SuppressTSqlWarnings` property in the project file:
+To supress specific warnings from being treated as errors, add a comma-separated list of warning codes to `SuppressTSqlWarnings` property in the project file:
 
 ```xml
 <Project Sdk="MSBuild.Sdk.SqlProj/1.11.0">
@@ -129,7 +129,6 @@ Suppression of some warnings from treating as errors can be done by adding comma
     </PropertyGroup>
 </Project>
 ```
-
 
 ## Pre- and post deployment scripts
 Support for pre- and post deployment scripts has been added in version 1.1.0. These scripts will be automatically executed when deploying the `.dacpac` to SQL Server.

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -18,6 +18,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public FileInfo RefactorLog { get; set; }
 
         public bool WarnAsError { get; set; }
-        public string Suppress { get; set; }
+        public string SuppressWarnings { get; set; }
     }
 }

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -16,5 +16,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public FileInfo PreDeploy { get; set; }
         public FileInfo PostDeploy { get; set; }
         public FileInfo RefactorLog { get; set; }
+
+        public bool WarnAsError { get; set; }
+        public string Suppress { get; set; }
     }
 }

--- a/src/DacpacTool/ModelValidationError.cs
+++ b/src/DacpacTool/ModelValidationError.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using Microsoft.SqlServer.Dac.Model;
 
@@ -47,6 +47,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         }
 
         public ModelErrorSeverity Severity { get => _severity; }
+
+        public int ErrorCode { get => _errorCode; }
 
         public override string ToString()
         {

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -14,6 +14,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
     {
         private bool? _modelValid;
 
+        private List<int> _suppressedWarnings = new List<int>();
+
         public void UsingVersion(SqlServerVersion version)
         {
             Model = new TSqlModel(version, Options);
@@ -112,7 +114,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 }
                 else if (modelError.Severity == ModelErrorSeverity.Warning && TreatTSqlWarningsAsErrors)
                 {
-                    if (!suppressWarnings.Contains(modelError.ErrorCode))
+                    if (!_suppressedWarnings.Contains(modelError.ErrorCode))
                     {
                         validationErrors++;
                     }
@@ -326,20 +328,18 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 stream.Write(buffer, 0, buffer.Length);
             }
         }
-
+        
         public bool TreatTSqlWarningsAsErrors { get; set; }
-
-        private List<int> suppressWarnings = new List<int>();
-
-        public void AddSuppressWarnings(string suppressList)
+        
+        public void AddWarningsToSuppress(string suppressionList)
         {
-            if (!string.IsNullOrEmpty(suppressList))
+            if (!string.IsNullOrEmpty(suppressionList))
             {
-                foreach (string str in suppressList.Split(new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string str in suppressionList.Split(new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
                 {
                     if (int.TryParse(str.Trim(), out var value))
                     {
-                        suppressWarnings.Add(value);
+                        _suppressedWarnings.Add(value);
                     }
                 }
             }

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Packaging;
 using System.Linq;
@@ -108,6 +109,13 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 if (modelError.Severity == ModelErrorSeverity.Error)
                 {
                     validationErrors++;
+                }
+                else if (modelError.Severity == ModelErrorSeverity.Warning && TreatTSqlWarningsAsErrors)
+                {
+                    if (!suppressWarnings.Contains(modelError.ErrorCode))
+                    {
+                        validationErrors++;
+                    }
                 }
 
                 Console.WriteLine(modelError.ToString());
@@ -317,6 +325,15 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 var buffer = Encoding.UTF8.GetBytes(parser.GenerateScript());
                 stream.Write(buffer, 0, buffer.Length);
             }
+        }
+
+        public bool TreatTSqlWarningsAsErrors { get; set; }
+
+        private List<int> suppressWarnings = new List<int>();
+
+        public void AddSuppressWarnings(string suppressList)
+        {
+            suppressWarnings.AddRange(suppressList.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(x => Convert.ToInt32(x)));
         }
     }
 }

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -333,7 +333,16 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         public void AddSuppressWarnings(string suppressList)
         {
-            suppressWarnings.AddRange(suppressList.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(x => Convert.ToInt32(x)));
+            if (!string.IsNullOrEmpty(suppressList))
+            {
+                foreach (string str in suppressList.Split(new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (int.TryParse(str.Trim(), out var value))
+                    {
+                        suppressWarnings.Add(value);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -135,7 +135,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             packageBuilder.TreatTSqlWarningsAsErrors = options.WarnAsError;
             if (options.Suppress != null)
             {
-                packageBuilder.AddSuppressWarnings(options.Suppress);
+                packageBuilder.AddWarningsToSuppress(options.Suppress);
             }
 
             // Validate the model

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -29,7 +29,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<string[]>(new string[] { "--sqlcmdvar", "-sc" }, "SqlCmdVariable(s) to include"),
 
                 new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
-                new Option<string>(new string[] { "--suppress", "-sp" }, "Warning(s) to suppress"),
+                new Option<string>(new string[] { "--suppresswarnings", "-spw" }, "Warning(s) to suppress"),
 #if DEBUG
                 new Option<bool>(new string[] { "--debug" }, "Waits for a debugger to attach")
 #endif
@@ -133,9 +133,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             //Add Warnings options
             packageBuilder.TreatTSqlWarningsAsErrors = options.WarnAsError;
-            if (options.Suppress != null)
+            if (options.SuppressWarnings != null)
             {
-                packageBuilder.AddWarningsToSuppress(options.Suppress);
+                packageBuilder.AddWarningsToSuppress(options.SuppressWarnings);
             }
 
             // Validate the model

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -27,6 +27,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<FileInfo>(new string[] { "--refactorlog" }, "Filename of optional refactor log script"),
                 new Option<string[]>(new string[] { "--property", "-p" }, "Properties to be set on the model"),
                 new Option<string[]>(new string[] { "--sqlcmdvar", "-sc" }, "SqlCmdVariable(s) to include"),
+
+                new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
+                new Option<string>(new string[] { "--suppress", "-sp" }, "Warning(s) to suppress"),
 #if DEBUG
                 new Option<bool>(new string[] { "--debug" }, "Waits for a debugger to attach")
 #endif
@@ -126,6 +129,13 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 {
                     throw new ArgumentException($"No input files found, missing {options.InputFile.Name}");
                 }
+            }
+
+            //Add Warnings options
+            packageBuilder.TreatTSqlWarningsAsErrors = options.WarnAsError;
+            if (options.Suppress != null)
+            {
+                packageBuilder.AddSuppressWarnings(options.Suppress);
             }
 
             // Validate the model

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
@@ -9,6 +9,8 @@
     <UsingMSBuildSdkSqlProj>true</UsingMSBuildSdkSqlProj>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
     <SqlServerVersion>Sql150</SqlServerVersion>
+    <TreatTSqlWarningsAsErrors>False</TreatTSqlWarningsAsErrors>
+    <SuppressTSqlWarnings></SuppressTSqlWarnings>
     <TargetExt>.dacpac</TargetExt>
   </PropertyGroup>
 

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
@@ -9,8 +9,6 @@
     <UsingMSBuildSdkSqlProj>true</UsingMSBuildSdkSqlProj>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
     <SqlServerVersion>Sql150</SqlServerVersion>
-    <TreatTSqlWarningsAsErrors>False</TreatTSqlWarningsAsErrors>
-    <SuppressTSqlWarnings></SuppressTSqlWarnings>
     <TargetExt>.dacpac</TargetExt>
   </PropertyGroup>
 

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -201,7 +201,9 @@
       <PostDeploymentScriptArgument>@(PostDeploy->'--postdeploy %(Identity)', ' ')</PostDeploymentScriptArgument>
       <RefactorLogScriptArgument>@(RefactorLog->'--refactorlog %(Identity)', ' ')</RefactorLogScriptArgument>
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
-      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(DebugArgument)</DacpacToolCommand>
+      <TreatTSqlWarningsAsErrorsArgument  Condition="'$(TreatTSqlWarningsAsErrors)' == 'True'">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
+      <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">--suppress &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
+      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(DebugArgument)</DacpacToolCommand>
     </PropertyGroup>
     <!-- Run it, except during design-time builds -->
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -201,7 +201,7 @@
       <PostDeploymentScriptArgument>@(PostDeploy->'--postdeploy %(Identity)', ' ')</PostDeploymentScriptArgument>
       <RefactorLogScriptArgument>@(RefactorLog->'--refactorlog %(Identity)', ' ')</RefactorLogScriptArgument>
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
-      <TreatTSqlWarningsAsErrorsArgument Condition="'$(TreatTSqlWarningsAsErrors)' == 'True'">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
+      <TreatTSqlWarningsAsErrorsArgument Condition="'$(TreatTSqlWarningsAsErrors)' == 'True' Or '$(TreatWarningsAsErrors)' == 'True'">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
       <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">-spw &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
       <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(DebugArgument)</DacpacToolCommand>
     </PropertyGroup>

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -202,7 +202,7 @@
       <RefactorLogScriptArgument>@(RefactorLog->'--refactorlog %(Identity)', ' ')</RefactorLogScriptArgument>
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
       <TreatTSqlWarningsAsErrorsArgument  Condition="'$(TreatTSqlWarningsAsErrors)' == 'True'">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
-      <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">--suppress &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
+      <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">-spw &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
       <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(DebugArgument)</DacpacToolCommand>
     </PropertyGroup>
     <!-- Run it, except during design-time builds -->

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -201,7 +201,7 @@
       <PostDeploymentScriptArgument>@(PostDeploy->'--postdeploy %(Identity)', ' ')</PostDeploymentScriptArgument>
       <RefactorLogScriptArgument>@(RefactorLog->'--refactorlog %(Identity)', ' ')</RefactorLogScriptArgument>
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
-      <TreatTSqlWarningsAsErrorsArgument  Condition="'$(TreatTSqlWarningsAsErrors)' == 'True'">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
+      <TreatTSqlWarningsAsErrorsArgument Condition="'$(TreatTSqlWarningsAsErrors)' == 'True'">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
       <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">-spw &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
       <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(DebugArgument)</DacpacToolCommand>
     </PropertyGroup>

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -477,6 +477,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             bool result = packageBuilder.ValidateModel();
 
             // Assert
+            // Because of setting TreatTSqlWarningsAsErrors to true, SQL71502 Warning would be treated as error
             result.ShouldBeFalse();
         }
 
@@ -487,7 +488,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageBuilder = new PackageBuilder();
             packageBuilder.UsingVersion(SqlServerVersion.Sql150);
             packageBuilder.TreatTSqlWarningsAsErrors = true;
-            packageBuilder.AddSuppressWarnings("71502");
+            packageBuilder.AddWarningsToSuppress("71502");
             packageBuilder.SetMetadata("MyPackage", "1.0.0.0");
             packageBuilder.Model.AddObjects("CREATE PROCEDURE [csp_Test] AS BEGIN SELECT * FROM [dbo].[MyTable] END");
 

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -464,6 +464,41 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         }
 
         [TestMethod]
+        public void ValidateModel_WarningsAsErrors()
+        {
+            // Arrange
+            var packageBuilder = new PackageBuilder();
+            packageBuilder.UsingVersion(SqlServerVersion.Sql150);
+            packageBuilder.TreatTSqlWarningsAsErrors = true;
+            packageBuilder.SetMetadata("MyPackage", "1.0.0.0");
+            packageBuilder.Model.AddObjects("CREATE PROCEDURE [csp_Test] AS BEGIN SELECT * FROM [dbo].[MyTable] END");
+
+            // Act
+            bool result = packageBuilder.ValidateModel();
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [TestMethod]
+        public void ValidateModel_WarningsAsErrorsSuppressGlobal()
+        {
+            // Arrange
+            var packageBuilder = new PackageBuilder();
+            packageBuilder.UsingVersion(SqlServerVersion.Sql150);
+            packageBuilder.TreatTSqlWarningsAsErrors = true;
+            packageBuilder.AddSuppressWarnings("71502");
+            packageBuilder.SetMetadata("MyPackage", "1.0.0.0");
+            packageBuilder.Model.AddObjects("CREATE PROCEDURE [csp_Test] AS BEGIN SELECT * FROM [dbo].[MyTable] END");
+
+            // Act
+            bool result = packageBuilder.ValidateModel();
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        [TestMethod]
         public void ValidateModel_Errors()
         {
             // Arrange

--- a/test/TestProjectWithWarningsSuppress/Procedures/csp_Test.sql
+++ b/test/TestProjectWithWarningsSuppress/Procedures/csp_Test.sql
@@ -1,0 +1,5 @@
+CREATE PROCEDURE [dbo].[csp_Test]
+AS
+BEGIN
+    SELECT * FROM [dbo].[MyTable];
+END

--- a/test/TestProjectWithWarningsSuppress/TestProjectWithWarningsSuppress.csproj
+++ b/test/TestProjectWithWarningsSuppress/TestProjectWithWarningsSuppress.csproj
@@ -5,8 +5,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <SqlServerVersion>Sql150</SqlServerVersion>
 
-      <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
-      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
+    <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />

--- a/test/TestProjectWithWarningsSuppress/TestProjectWithWarningsSuppress.csproj
+++ b/test/TestProjectWithWarningsSuppress/TestProjectWithWarningsSuppress.csproj
@@ -1,0 +1,13 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <SqlServerVersion>Sql150</SqlServerVersion>
+
+      <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+</Project>


### PR DESCRIPTION
In standard Microsoft Database project there is an options controlling how to treat T-SQL Warnings.
The global project option TreatTSqlWarningsAsErrors tells to break compiling on any waring  is occured. Individual warnings can be suppressed by SuppressTSqlWarnings option. It is a list of warning codes.

So I try to add support for both options at project level. Suppressing warnings for individual files may be done later.
To use it simply add 
```
<TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
<SuppressTSqlWarnings>71558</SuppressTSqlWarnings>
```
to Project PropertyGroup.

Added test Project TestProjectWithWarningsSuppress
Added tests to DacpacTool.Tests