### PR TITLE
Apply TargetDatabaseName in GenerateCreateScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,6 @@ With this enabled you'll find a SQL script with the name `<database-name>_Create
 The database name for the create script gets resolved in the following manner:
 1. `TargetDatabaseName`.
 1. Package name.
-1. DacPac file name without extension.
 > Note: the generated script also uses the resolved database name via a setvar command.
 
 ## Workaround for parser errors (SQL46010)

--- a/README.md
+++ b/README.md
@@ -457,7 +457,12 @@ Instead of using `dotnet publish` to deploy changes to a database, you can also 
 </Project>
 ```
 
-With this enabled you'll find a SQL script with the name `<datbase-name>_Create.sql` in the bin folder.
+With this enabled you'll find a SQL script with the name `<database-name>_Create.sql` in the bin folder.
+The database name for the create script gets resolved in the following manner:
+1. `TargetDatabaseName`.
+1. Package name.
+1. DacPac file name without extension.
+> Note: the generated script also uses the resolved database name via a setvar command.
 
 ## Workaround for parser errors (SQL46010)
 This project relies on the publicly available T-SQL parser which may not support all T-SQL syntax constructions. Therefore you might encounter a SQL46010 error if you have a script file that contains unsupported syntax. If that happens, there's a couple of workarounds you can try:

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -21,5 +21,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public string SuppressWarnings { get; set; }
         public FileInfo SuppressWarningsListFile { get; set; }
         public bool GenerateCreateScript { get; set; }
+        public string TargetDatabaseName { get; set; }
     }
 }

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -391,9 +391,12 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         public void GenerateCreateScript(FileInfo dacpacFile, string databaseName)
         {
-            databaseName ??= Path.GetFileNameWithoutExtension(dacpacFile.Name);
-            var scriptFileName = $"{databaseName}_Create.sql";
+            if (databaseName is null)
+            {
+                throw new ArgumentNullException(nameof(databaseName));
+            }
 
+            var scriptFileName = $"{databaseName}_Create.sql";
             Console.WriteLine($"Generating create script {scriptFileName}");
 
             using var package = DacPackage.Load(dacpacFile.FullName);

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -391,9 +391,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         public void GenerateCreateScript(FileInfo dacpacFile, string databaseName)
         {
-            if (databaseName is null)
+            if (string.IsNullOrWhiteSpace(databaseName))
             {
-                throw new ArgumentNullException(nameof(databaseName));
+                throw new ArgumentException("The database name is mandatory.", nameof(databaseName));
             }
 
             var scriptFileName = $"{databaseName}_Create.sql";

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -30,6 +30,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
                 new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
                 new Option<bool>(new string[] { "--generatecreatescript", "-gcs" }, "Generate create script for package"),
+                new Option<string>(new string[] { "--targetdatabasename", "-tdn" }, "Name of the database to use in the generated create script"),
                 new Option<string>(new string[] { "--suppresswarnings", "-spw" }, "Warning(s) to suppress"),
                 new Option<FileInfo>(new string[] { "--suppresswarningslistfile", "-spl" }, "Filename for warning(s) to suppress for particular files"),
 #if DEBUG
@@ -172,7 +173,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             if (options.GenerateCreateScript)
             {
-                packageBuilder.GenerateCreateScript(options.Output, options.Name);
+                packageBuilder.GenerateCreateScript(options.Output, options.TargetDatabaseName ?? options.Name);
             }
 
             return 0;

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -16,7 +16,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         {
             var buildCommand = new Command("build")
             {
-                new Option<string>(new string[] { "--name", "-n" }, "Name of the package"),
+                new Option<string>(new string[] { "--name", "-n" }, "Name of the package") { IsRequired = true },
                 new Option<string>(new string[] { "--version", "-v" }, "Version of the package"),
                 new Option<FileInfo>(new string[] { "--output", "-o" }, "Filename of the output package"),
                 new Option<SqlServerVersion>(new string[] { "--sqlServerVersion", "-sv" }, () => SqlServerVersion.Sql150, description: "Target version of the model"),

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -218,9 +218,10 @@
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
       <TreatTSqlWarningsAsErrorsArgument Condition="'$(TreatTSqlWarningsAsErrors)' == 'True' Or '$(TreatWarningsAsErrors)' == 'True'">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
       <GenerateCreateScriptArgument Condition="'$(GenerateCreateScript)' == 'True'">--generatecreatescript</GenerateCreateScriptArgument>
+      <TargetDatabaseNameArgument Condition="'$(TargetDatabaseName)' != '$(MSBuildProjectName)'">-tdn &quot;$(TargetDatabaseName)&quot;</TargetDatabaseNameArgument>
       <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">-spw &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
       <WarningsSuppressionListArgument Condition="'@(WarningsSuppressionFiles->'%(Identity)')'!=''">-spl &quot;$(IntermediateOutputPath)$(MSBuildProjectName).WarningsSuppression.txt&quot;</WarningsSuppressionListArgument>
-      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument)</DacpacToolCommand>
+      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument)</DacpacToolCommand>
     </PropertyGroup>
     <!-- Run it, except during design-time builds -->
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -592,11 +592,10 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
 
             // Act
             packageBuilder.SaveToDisk(tempFile);
-            packageBuilder.GenerateCreateScript(tempFile, null);
-
+            
             // Assert
-            File.Exists(Path.Combine(tempFile.DirectoryName, $"{Path.GetFileNameWithoutExtension(tempFile.Name)}_Create.sql")).ShouldBeTrue();
-
+            Should.Throw<ArgumentNullException>(() => packageBuilder.GenerateCreateScript(tempFile, null));
+            
             // Cleanup
             tempFile.Delete();
         }

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -594,7 +594,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             packageBuilder.SaveToDisk(tempFile);
             
             // Assert
-            Should.Throw<ArgumentNullException>(() => packageBuilder.GenerateCreateScript(tempFile, null));
+            Should.Throw<ArgumentException>(() => packageBuilder.GenerateCreateScript(tempFile, null));
             
             // Cleanup
             tempFile.Delete();

--- a/test/DacpacTool.Tests/ScriptParserTests.cs
+++ b/test/DacpacTool.Tests/ScriptParserTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.SqlTools.ServiceLayer.BatchParser;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Linq;
 using NSubstitute;
 using Shouldly;
@@ -171,7 +172,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
 
             // Act / Assert
             Should.Throw<System.InvalidOperationException>(() => collector.CollectFileNames())
-                .Message.ShouldBe("Incorrect syntax was encountered while parsing '\n'. File: ScriptWithErrors.sql");
+                .Message.ShouldBe($"Incorrect syntax was encountered while parsing '{Environment.NewLine}'. File: ScriptWithErrors.sql");
         }
     }
 }

--- a/test/TestProjectWithGenerateScriptAndTargetDatabaseName/Tables/MyTable.sql
+++ b/test/TestProjectWithGenerateScriptAndTargetDatabaseName/Tables/MyTable.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[MyTable]
+(
+    Column1 nvarchar(100),
+    Column2 int
+);

--- a/test/TestProjectWithGenerateScriptAndTargetDatabaseName/TestProjectWithGenerateScriptAndTargetDatabaseName.csproj
+++ b/test/TestProjectWithGenerateScriptAndTargetDatabaseName/TestProjectWithGenerateScriptAndTargetDatabaseName.csproj
@@ -1,0 +1,21 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <SqlServerVersion>Sql150</SqlServerVersion>
+    <RecoveryMode>Simple</RecoveryMode>
+    <AllowSnapshotIsolation>True</AllowSnapshotIsolation>
+    <ReadCommittedSnapshot>True</ReadCommittedSnapshot>
+    <ServiceBrokerOption>EnableBroker</ServiceBrokerOption>
+    <PackageProjectUrl>https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/</PackageProjectUrl>
+    <GenerateCreateScript>True</GenerateCreateScript>
+    <TargetDatabaseName>MyDatabaseName</TargetDatabaseName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ExcludeObjectTypes>Users,Assemblies</ExcludeObjectTypes>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+</Project>


### PR DESCRIPTION
Apply `TargetDatabaseName`, which is normally used for publishing the dacpac, to the generated create script as well. See issue #186 