### PR TITLE
Allow project reference from vanilla classlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,17 @@ DECLARE @Query NVARCHAR(MAX) = '<your-script>'
 EXEC (@Query)
 ```
 
+## Reference `MSBuild.Sdk.SqlProj` from class library
+The output of `MSBuild.Sdk.SqlProj` is not an assembly, but a `.dacpac`. In order to correctly reference a `MSBuild.Sdk.SqlProj` based project from a class library, the `ReferenceOutputAssembly` hint needs to be set to `False`:
+```
+<ItemGroup>
+    <ProjectReference
+      Include="../MyDacpacProj/MyDacpacProj.csproj"
+      ReferenceOutputAssembly="False" />
+</ItemGroup>
+```
+Now, upon compilation of the class library, the relevant `.dacpac` files get copied to the output directory.
+
 ## Known limitations
 Since this is not an entire project system but only an MSBuild SDK we cannot provide IntelliSense for objects defined within the project. This limitation can be circumvented by connecting the SQL editor to a live database that is used for development purposes.
 

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -279,6 +279,7 @@
     <Exec Command="$(DacpacToolCommand)" />
   </Target>
   
+  <!-- Lists all dacpac files of interest to the current project, so that a referencing class library can copy these to its output directory -->
   <Target Name="CopyDacpacs" BeforeTargets="GetCopyToOutputDirectoryItems">
     <ItemGroup>
       <CopyDacpacFiles Include="$(TargetPath)"/>

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -280,11 +280,12 @@
   </Target>
   
   <Target Name="CopyDacpacs" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <CreateItem Include="$(IntermediateOutputPath)*.dacpac">
-        <Output TaskParameter="Include" ItemName="CopyDacpacFiles" />
-    </CreateItem>
     <ItemGroup>
-      <AllItemsFullPathWithTargetPath Include="@(CopyDacpacFiles->'%(FullPath)')">
+      <CopyDacpacFiles Include="$(TargetPath)"/>
+      <CopyDacpacFiles Include="@(DacpacReference->'%(DacpacFile)')"/>
+    </ItemGroup>
+    <ItemGroup>
+      <AllItemsFullPathWithTargetPath Include="@(CopyDacpacFiles)">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         <TargetPath>%(Filename)%(Extension)</TargetPath>
       </AllItemsFullPathWithTargetPath>

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -279,4 +279,16 @@
     <Exec Command="$(DacpacToolCommand)" />
   </Target>
   
+  <Target Name="CopyDacpacs" BeforeTargets="GetCopyToOutputDirectoryItems">
+    <CreateItem Include="$(IntermediateOutputPath)*.dacpac">
+        <Output TaskParameter="Include" ItemName="CopyDacpacFiles" />
+    </CreateItem>
+    <ItemGroup>
+      <AllItemsFullPathWithTargetPath Include="@(CopyDacpacFiles->'%(FullPath)')">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      </AllItemsFullPathWithTargetPath>
+    </ItemGroup>
+    <Message Importance="Low" Text="CopyDacpacFiles: @(CopyDacpacFiles)" />
+  </Target>
 </Project>

--- a/test/TestIncludeFromVanillaProj/Class1.cs
+++ b/test/TestIncludeFromVanillaProj/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace TestIncludeFromVanillaProj
+{
+    public class Class1
+    {
+    }
+}

--- a/test/TestIncludeFromVanillaProj/TestIncludeFromVanillaProj.csproj
+++ b/test/TestIncludeFromVanillaProj/TestIncludeFromVanillaProj.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <ProjectReference Include="../TestProjectWithWarnings/TestProjectWithWarnings.csproj">
+        <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      </ProjectReference>
+
+      <ProjectReference Include="../TestProjectWithProjectReference/TestProjectWithProjectReference.csproj">
+        <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/test/TestIncludeFromVanillaProj/TestIncludeFromVanillaProj.csproj
+++ b/test/TestIncludeFromVanillaProj/TestIncludeFromVanillaProj.csproj
@@ -5,13 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <ProjectReference Include="../TestProjectWithWarnings/TestProjectWithWarnings.csproj">
-        <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-      </ProjectReference>
-
-      <ProjectReference Include="../TestProjectWithProjectReference/TestProjectWithProjectReference.csproj">
-        <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-      </ProjectReference>
+      <ProjectReference Include="../TestProjectWithWarnings/TestProjectWithWarnings.csproj" ReferenceOutputAssembly="False" />
+      <ProjectReference Include="../TestProjectWithProjectReference/TestProjectWithProjectReference.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
 
 </Project>

--- a/test/TestIncludeFromVanillaProjWithExternalPackageReference/Class1.cs
+++ b/test/TestIncludeFromVanillaProjWithExternalPackageReference/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace TestIncludeFromVanillaProj
+{
+    public class Class1
+    {
+    }
+}

--- a/test/TestIncludeFromVanillaProjWithExternalPackageReference/TestIncludeFromVanillaProjWithExternalPackageReference.csproj
+++ b/test/TestIncludeFromVanillaProjWithExternalPackageReference/TestIncludeFromVanillaProjWithExternalPackageReference.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <ProjectReference Include="../TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReference.csproj">
+        <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/test/TestIncludeFromVanillaProjWithExternalPackageReference/TestIncludeFromVanillaProjWithExternalPackageReference.csproj
+++ b/test/TestIncludeFromVanillaProjWithExternalPackageReference/TestIncludeFromVanillaProjWithExternalPackageReference.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <ProjectReference Include="../TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReference.csproj">
-        <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-      </ProjectReference>
+      <ProjectReference Include="../TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReference.csproj" ReferenceOutputAssembly="False" />
   </ItemGroup>
 
 </Project>

--- a/test/TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReference.csproj
+++ b/test/TestProjectWithExternalPackageReference/TestProjectWithExternalPackageReference.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TestProject" Version="1.2.0-beta.9.gf2d69b1c16" DatabaseVariableLiteralValue="SomeOtherDatabase" />
+    <PackageReference Include="TestProject" Version="1.17.0-beta.23.g92605d805a" DatabaseVariableLiteralValue="SomeOtherDatabase" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)../../src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets" />


### PR DESCRIPTION
This solves #117 

Take care to add `<ReferenceOutputAssembly>False</ReferenceOutputAssembly>` to the project reference. Without it, the compilation of the vanilla class library will fail; a `.dacpac` file is not a valid assembly ;-)

The target `GetCopyToOutputDirectoryItems` returns an `AllItemsFullPathWithTargetPath` item collection. The new target `CopyDacpacs` runs before `GetCopyToOutputDirectoryItems` and preloads `AllItemsFullPathWithTargetPath` with the project's dacpac file and all referenced dacpac files.

Two test projects prove that the referenced dacpac files get copied to the bin folder of the vanilla class library project:
- TestIncludeFromVanillaProj
This uses a `ProjectReference` to a dacpac project with a nested `ProjectReference`.
- TestIncludeFromVanillaProjWithExternalPackageReference
This uses a 'ProjectReference' to a dacpac project with a nested dacpac `PackageReference`.