### PR TITLE
Include README.md in the nuget package

### DIFF
--- a/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.nuspec
+++ b/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.nuspec
@@ -14,10 +14,12 @@
       <packageType name="$packagetype$" />
     </packageTypes>
     <repository type="git" url="https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/" />
+    <readme>docs\README.md</readme>
   </metadata>
   <files>
     <file src="Sdk\**" target="Sdk" />
     <file src="tools\**" target="tools" />
     <file src="LICENSE.txt" target="LICENSE.txt" />
+    <file src="..\..\README.md" target="docs\" />
   </files>
 </package>


### PR DESCRIPTION
Implemented as per https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/
@jmezach Can you please [verify](https://docs.microsoft.com/en-us/nuget/nuget-org/publish-a-package#web-portal-use-the-upload-package-tab-on-nugetorg) that the readme shows up?