### PR TITLE
Include composite objects from external references when generating script file

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ Instead of using `dotnet publish` to deploy changes to a database, you can also 
 ```xml
 <Project Sdk="MSBuild.Sdk.SqlProj/1.15.0">
   <PropertyGroup>
-    <GenerateCreateScript>True</GenerateCreateScript>
+      <GenerateCreateScript>True</GenerateCreateScript>
+      <IncludeCompositeObjects>True</IncludeCompositeObjects>
   </PropertyGroup>
 </Project>
 ```
@@ -464,7 +465,7 @@ The database name for the create script gets resolved in the following manner:
 1. Package name.
 > Note: 
 >- the generated script also uses the resolved database name via a setvar command.
->- the composite objects (tables, etc.) from external references are also included in the generated script   
+>- if `IncludeCompositeObjects` is true, the composite objects (tables, etc.) from external references are also included in the generated script   
 
 ## Workaround for parser errors (SQL46010)
 This project relies on the publicly available T-SQL parser which may not support all T-SQL syntax constructions. Therefore you might encounter a SQL46010 error if you have a script file that contains unsupported syntax. If that happens, there's a couple of workarounds you can try:

--- a/README.md
+++ b/README.md
@@ -462,7 +462,9 @@ With this enabled you'll find a SQL script with the name `<database-name>_Create
 The database name for the create script gets resolved in the following manner:
 1. `TargetDatabaseName`.
 1. Package name.
-> Note: the generated script also uses the resolved database name via a setvar command.
+> Note: 
+>- the generated script also uses the resolved database name via a setvar command.
+>- the composite objects (tables, etc.) from external references are also included in the generated script   
 
 ## Workaround for parser errors (SQL46010)
 This project relies on the publicly available T-SQL parser which may not support all T-SQL syntax constructions. Therefore you might encounter a SQL46010 error if you have a script file that contains unsupported syntax. If that happens, there's a couple of workarounds you can try:

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ The database name for the create script gets resolved in the following manner:
 1. Package name.
 > Note: 
 >- the generated script also uses the resolved database name via a setvar command.
->- if `IncludeCompositeObjects` is true, the composite objects (tables, etc.) from external references are also included in the generated script   
+>- if `IncludeCompositeObjects` is true, the composite objects (tables, etc.) from external references are also included in the generated script. This property defaults to `true`   
 
 ## Workaround for parser errors (SQL46010)
 This project relies on the publicly available T-SQL parser which may not support all T-SQL syntax constructions. Therefore you might encounter a SQL46010 error if you have a script file that contains unsupported syntax. If that happens, there's a couple of workarounds you can try:

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -21,6 +21,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public string SuppressWarnings { get; set; }
         public FileInfo SuppressWarningsListFile { get; set; }
         public bool GenerateCreateScript { get; set; }
+        public bool IncludeCompositeObjects { get; set; }
         public string TargetDatabaseName { get; set; }
     }
 }

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -389,7 +389,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             return result;
         }
 
-        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName)
+        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName, bool includeCompositeObjects = false)
         {
             if (string.IsNullOrWhiteSpace(databaseName))
             {
@@ -402,7 +402,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             using var package = DacPackage.Load(dacpacFile.FullName);
             using var file = File.Create(Path.Combine(dacpacFile.DirectoryName, scriptFileName));
 
-            var options = new DacDeployOptions() { IncludeCompositeObjects = true };
+            var options = new DacDeployOptions() { IncludeCompositeObjects = includeCompositeObjects };
             DacServices.GenerateCreateScript(file, package, databaseName, options);
         }
     }

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -161,7 +161,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             EnsureModelCreated();
             EnsureModelValidated();
             EnsureMetadataCreated();
-
+            
             // Check if the file already exists
             if (outputFile.Exists)
             {
@@ -347,9 +347,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 stream.Write(buffer, 0, buffer.Length);
             }
         }
-
+        
         public bool TreatTSqlWarningsAsErrors { get; set; }
-
+        
         public void AddWarningsToSuppress(string suppressionList)
         {
             _suppressedWarnings.AddRange(ParseSuppressionList(suppressionList));
@@ -369,7 +369,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     list.AddRange(warningList.FindAll((x) => !list.Contains(x)));
                 }
             }
-
+                
         }
 
         private List<int> ParseSuppressionList(string suppressionList)

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -389,7 +389,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             return result;
         }
 
-        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName, bool includeCompositeObjects = false)
+        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName, bool includeCompositeObjects)
         {
             if (string.IsNullOrWhiteSpace(databaseName))
             {

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -161,7 +161,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             EnsureModelCreated();
             EnsureModelValidated();
             EnsureMetadataCreated();
-            
+
             // Check if the file already exists
             if (outputFile.Exists)
             {
@@ -347,9 +347,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 stream.Write(buffer, 0, buffer.Length);
             }
         }
-        
+
         public bool TreatTSqlWarningsAsErrors { get; set; }
-        
+
         public void AddWarningsToSuppress(string suppressionList)
         {
             _suppressedWarnings.AddRange(ParseSuppressionList(suppressionList));
@@ -369,7 +369,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     list.AddRange(warningList.FindAll((x) => !list.Contains(x)));
                 }
             }
-                
+
         }
 
         private List<int> ParseSuppressionList(string suppressionList)
@@ -401,7 +401,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             using var package = DacPackage.Load(dacpacFile.FullName);
             using var file = File.Create(Path.Combine(dacpacFile.DirectoryName, scriptFileName));
-            DacServices.GenerateCreateScript(file, package, databaseName);
+
+            var options = new DacDeployOptions() { IncludeCompositeObjects = true };
+            DacServices.GenerateCreateScript(file, package, databaseName, options);
         }
     }
 }

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -30,6 +30,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
                 new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
                 new Option<bool>(new string[] { "--generatecreatescript", "-gcs" }, "Generate create script for package"),
+                new Option<bool>(new string[] { "--includeCompositeObjects", "-ico" }, "Include referenced, external elements that also compose the source model"),
                 new Option<string>(new string[] { "--targetdatabasename", "-tdn" }, "Name of the database to use in the generated create script"),
                 new Option<string>(new string[] { "--suppresswarnings", "-spw" }, "Warning(s) to suppress"),
                 new Option<FileInfo>(new string[] { "--suppresswarningslistfile", "-spl" }, "Filename for warning(s) to suppress for particular files"),
@@ -128,7 +129,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                         packageBuilder.AddInputFile(inputFile);
                     }
                 }
-                else 
+                else
                 {
                     throw new ArgumentException($"No input files found, missing {options.InputFile.Name}");
                 }
@@ -173,7 +174,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             if (options.GenerateCreateScript)
             {
-                packageBuilder.GenerateCreateScript(options.Output, options.TargetDatabaseName ?? options.Name);
+                packageBuilder.GenerateCreateScript(options.Output, options.TargetDatabaseName ?? options.Name, options.IncludeCompositeObjects);
             }
 
             return 0;
@@ -184,7 +185,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             var scriptInspector = new ScriptInspector();
 
             // Add predeployment and postdeployment scripts
-            if (options.PreDeploy != null) 
+            if (options.PreDeploy != null)
             {
                 scriptInspector.AddPreDeploymentScript(options.PreDeploy);
             }
@@ -238,7 +239,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 {
                     deployer.UseTargetServer(options.TargetServerName);
                 }
-                
+
                 if (!string.IsNullOrWhiteSpace(options.TargetUser))
                 {
                     deployer.UseSqlAuthentication(options.TargetUser, options.TargetPassword);

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -30,7 +30,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
                 new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
                 new Option<bool>(new string[] { "--generatecreatescript", "-gcs" }, "Generate create script for package"),
-                new Option<bool>(new string[] { "--includeCompositeObjects", "-ico" }, "Include referenced, external elements that also compose the source model"),
+                new Option<bool>(new string[] { "--includecompositeobjects", "-ico" }, "Include referenced, external elements that also compose the source model"),
                 new Option<string>(new string[] { "--targetdatabasename", "-tdn" }, "Name of the database to use in the generated create script"),
                 new Option<string>(new string[] { "--suppresswarnings", "-spw" }, "Warning(s) to suppress"),
                 new Option<FileInfo>(new string[] { "--suppresswarningslistfile", "-spl" }, "Filename for warning(s) to suppress for particular files"),

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -8,7 +8,7 @@
   <!--
     Set LanguageTargets to Microsoft.Common.targets for any project that the SDK won't (.proj, .noproj, etc)
     https://github.com/dotnet/sdk/blob/50ddfbb91be94d068514e8f4b0ce1052156364a0/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L28
-    
+
     We can't default LanguageTargets it is set in the SDK and immediately imported.  So we can only default
     it if we know the SDK won't.  Projects probably won't load in Visual Studio but will build from the
     command-line just fine.
@@ -21,7 +21,7 @@
   <Import Project="$(CustomBeforeNoTargets)" Condition="'$(CustomBeforeNoTargets)' != '' and Exists('$(CustomBeforeNoTargets)')" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
-  
+
   <ItemGroup>
     <!-- Override primary output path to be a .dacpac -->
     <_IntermediateAssembly Include="@(IntermediateAssembly)" />
@@ -73,12 +73,12 @@
   <Target Name="ComputeIntermediateSatelliteAssemblies" />
 
   <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets" 
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets"
           Condition="'$(DebuggerFlavor)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')" />
 
   <Import Project="$(CustomAfterNoTargets)" Condition="'$(CustomAfterNoTargets)' != '' and Exists('$(CustomAfterNoTargets)')" />
 
-  <!-- 
+  <!--
     Microsoft.Managed.Targets is imported by the managed language target files in MSBuild 16.0 and above, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
     So import it when the managed targets do not get imported.
   -->
@@ -105,14 +105,14 @@
     location of the package and then checking if a that package contains a .dacpac file inside of the tools folder.
   -->
   <Target Name="ResolveDatabaseReferences">
-    <ItemGroup> 
+    <ItemGroup>
       <!-- Resolve all package references to their physical location first -->
       <_ResolvedPackageReference Include="%(PackageReference.Identity)">
         <!-- Determine technical name of package (ie. Foo.Bar.Database -> Foo_Bar_Database) -->
         <PackageName>@(PackageReference->'%(Identity)'->Replace('.', '_'))</PackageName>
         <!-- Prepend Pkg to technical name from above and resolve variable (ie. Foo_Bar_Database -> %home%\.nuget\packages\foo.bar.database\<version> -->
         <PhysicalLocation>$(Pkg%(_ResolvedPackageReference.PackageName))</PhysicalLocation>
-        <!-- 
+        <!--
           If no Pkg<package-id> property is available, fall back to deriving the physical location from several other properties.
           This isn't guaranteed to be correct, particularly when floating versions are used, but will successfully resolve most of the time.
         -->
@@ -131,7 +131,7 @@
         <!-- Constructs variable to make external parts -->
         <ExternalParts>dbl=%(_ResolvedProjectReferencePaths.DatabaseVariableLiteralValue)|dbv=%(_ResolvedProjectReferencePaths.DatabaseSqlCmdVariable)|srv=%(_ResolvedProjectReferencePaths.ServerSqlCmdVariable)</ExternalParts>
       </_ResolvedProjectReference>
-    
+
       <!-- Build a list of package/project references that include a dacpac file matching the package identity in their tools folder -->
       <DacpacReference Include="@(_ResolvedPackageReference);@(_ResolvedProjectReference)" Condition="Exists(%(DacpacFile))" />
     </ItemGroup>
@@ -175,7 +175,7 @@
   <!--
     Performs the actual compilation of the input files (*.sql) into a .dacpac package by calling into a command line tool to do the actual work.
   -->
-  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabaseReferences;GetIncludedFiles" 
+  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabaseReferences;GetIncludedFiles"
           Inputs="@(Content);@(PreDeploy);@(PostDeploy);@(RefactorLog);$(IncludedFiles);$(ProjectPath)" Outputs="$(TargetPath)">
     <ItemGroup>
       <!-- Get the values for known model properties specified in the project file -->
@@ -183,7 +183,7 @@
       <PropertyNames Include="@(_PropertyNames)" Condition=" '$(%(Identity))' != '' ">
         <PropertyValue>$(%(_PropertyNames.Identity))</PropertyValue>
       </PropertyNames>
-      
+
       <!-- Compile the list of references -->
       <IncludedDacpacReferenceFiles Include="@(DacpacReference->'%(DacpacFile)')" />
     </ItemGroup>
@@ -199,7 +199,7 @@
       <!-- Build a list of particular files with T-SQL warning suppression -->
       <WarningsSuppressionFiles Include="@(Content->'%(Identity)|%(SuppressTSqlWarnings)')" Condition="'%(Content.SuppressTSqlWarnings)' != ''"/>
     </ItemGroup>
-    <WriteLinesToFile 
+    <WriteLinesToFile
       File="$(IntermediateOutputPath)$(MSBuildProjectName).WarningsSuppression.txt"
       Overwrite="true"
       Lines="@(WarningsSuppressionFiles)" />
@@ -219,10 +219,11 @@
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
       <TreatTSqlWarningsAsErrorsArgument Condition="'$(TreatTSqlWarningsAsErrors)' == 'True' Or ('$(TreatWarningsAsErrors)' == 'True' And '$(TreatTSqlWarningsAsErrors)' == '')">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
       <GenerateCreateScriptArgument Condition="'$(GenerateCreateScript)' == 'True'">--generatecreatescript</GenerateCreateScriptArgument>
+      <IncludeCompositeObjectsArgument Condition="'$(IncludeCompositeObjects)' == 'True'">--includecompositeobjects</IncludeCompositeObjectsArgument>
       <TargetDatabaseNameArgument Condition="'$(TargetDatabaseName)' != '$(MSBuildProjectName)'">-tdn &quot;$(TargetDatabaseName)&quot;</TargetDatabaseNameArgument>
       <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">-spw &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
       <WarningsSuppressionListArgument Condition="'@(WarningsSuppressionFiles->'%(Identity)')'!=''">-spl &quot;$(IntermediateOutputPath)$(MSBuildProjectName).WarningsSuppression.txt&quot;</WarningsSuppressionListArgument>
-      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument)</DacpacToolCommand>
+      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument) $(IncludeCompositeObjectsArgument)</DacpacToolCommand>
     </PropertyGroup>
     <!-- Run it, except during design-time builds -->
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />
@@ -280,7 +281,7 @@
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />
     <Exec Command="$(DacpacToolCommand)" />
   </Target>
-  
+
   <!-- Lists all dacpac files of interest to the current project, so that a referencing class library can copy these to its output directory -->
   <Target Name="CopyDacpacs" BeforeTargets="GetCopyToOutputDirectoryItems">
     <ItemGroup>

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -571,7 +571,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
 
             // Act
             packageBuilder.SaveToDisk(tempFile);
-            packageBuilder.GenerateCreateScript(tempFile, packageName);
+            packageBuilder.GenerateCreateScript(tempFile, packageName, false);
 
             // Assert
             File.Exists(Path.Combine(tempFile.DirectoryName, $"{packageName}_Create.sql")).ShouldBeTrue();
@@ -635,7 +635,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             packageBuilder.SaveToDisk(tempFile);
 
             // Assert
-            Should.Throw<ArgumentException>(() => packageBuilder.GenerateCreateScript(tempFile, null));
+            Should.Throw<ArgumentException>(() => packageBuilder.GenerateCreateScript(tempFile, null, false));
 
             // Cleanup
             tempFile.Delete();


### PR DESCRIPTION
Add an `IncludeCompositeObjects` option that allows to include objects from the referenced database packages when generating the script file