### PR TITLE
Pass down KnownDeployProperties to the GenerateCreateScript functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ Instead of using `dotnet publish` to deploy changes to a database, you can also 
 ```xml
 <Project Sdk="MSBuild.Sdk.SqlProj/1.15.0">
   <PropertyGroup>
-    <GenerateCreateScript>True</GenerateCreateScript>
+      <GenerateCreateScript>True</GenerateCreateScript>
+      <IncludeCompositeObjects>True</IncludeCompositeObjects>
   </PropertyGroup>
 </Project>
 ```
@@ -464,7 +465,7 @@ The database name for the create script gets resolved in the following manner:
 1. Package name.
 > Note: 
 >- the generated script also uses the resolved database name via a setvar command.
->- the composite objects (tables, etc.) from external references are also included in the generated script   
+>- if `IncludeCompositeObjects` is true, the composite objects (tables, etc.) from external references are also included in the generated script   
 
 ## Workaround for parser errors (SQL46010)
 This project relies on the publicly available T-SQL parser which may not support all T-SQL syntax constructions. Therefore you might encounter a SQL46010 error if you have a script file that contains unsupported syntax. If that happens, there's a couple of workarounds you can try:

--- a/README.md
+++ b/README.md
@@ -462,7 +462,9 @@ With this enabled you'll find a SQL script with the name `<database-name>_Create
 The database name for the create script gets resolved in the following manner:
 1. `TargetDatabaseName`.
 1. Package name.
-> Note: the generated script also uses the resolved database name via a setvar command.
+> Note: 
+>- the generated script also uses the resolved database name via a setvar command.
+>- the composite objects (tables, etc.) from external references are also included in the generated script   
 
 ## Workaround for parser errors (SQL46010)
 This project relies on the publicly available T-SQL parser which may not support all T-SQL syntax constructions. Therefore you might encounter a SQL46010 error if you have a script file that contains unsupported syntax. If that happens, there's a couple of workarounds you can try:

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ The database name for the create script gets resolved in the following manner:
 1. Package name.
 > Note: 
 >- the generated script also uses the resolved database name via a setvar command.
->- if `IncludeCompositeObjects` is true, the composite objects (tables, etc.) from external references are also included in the generated script   
+>- if `IncludeCompositeObjects` is true, the composite objects (tables, etc.) from external references are also included in the generated script. This property defaults to `true`   
 
 ## Workaround for parser errors (SQL46010)
 This project relies on the publicly available T-SQL parser which may not support all T-SQL syntax constructions. Therefore you might encounter a SQL46010 error if you have a script file that contains unsupported syntax. If that happens, there's a couple of workarounds you can try:

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -11,8 +11,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public SqlServerVersion SqlServerVersion { get; set; }
         public FileInfo InputFile { get; set; }
         public string[] Reference { get; set; }
-        public string[] Property { get; set; }
-        public string[] CreateScriptProperty { get; set; }
+        public string[] BuildProperty { get; set; }
+        public string[] DeployProperty { get; set; }
         public string[] SqlCmdVar { get; set; }
         public FileInfo PreDeploy { get; set; }
         public FileInfo PostDeploy { get; set; }

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -12,6 +12,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public FileInfo InputFile { get; set; }
         public string[] Reference { get; set; }
         public string[] Property { get; set; }
+        public string[] CreateScriptProperty { get; set; }
         public string[] SqlCmdVar { get; set; }
         public FileInfo PreDeploy { get; set; }
         public FileInfo PostDeploy { get; set; }
@@ -21,7 +22,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public string SuppressWarnings { get; set; }
         public FileInfo SuppressWarningsListFile { get; set; }
         public bool GenerateCreateScript { get; set; }
-        public bool IncludeCompositeObjects { get; set; }
         public string TargetDatabaseName { get; set; }
     }
 }

--- a/src/DacpacTool/BuildOptions.cs
+++ b/src/DacpacTool/BuildOptions.cs
@@ -21,6 +21,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public string SuppressWarnings { get; set; }
         public FileInfo SuppressWarningsListFile { get; set; }
         public bool GenerateCreateScript { get; set; }
+        public bool IncludeCompositeObjects { get; set; }
         public string TargetDatabaseName { get; set; }
     }
 }

--- a/src/DacpacTool/DatabaseProperty.cs
+++ b/src/DacpacTool/DatabaseProperty.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace MSBuild.Sdk.SqlProj.DacpacTool
+{
+    public class DatabaseProperty
+    {
+        private DatabaseProperty(string name, string value)
+        {
+            this.Name = name;
+            this.Value = value;
+        }
+
+        public string Name { get; }
+
+        public string Value { get; }
+
+        public static DatabaseProperty Create(string property)
+        {
+            var propertyKeyValuePair = property.Split('=', 2, StringSplitOptions.RemoveEmptyEntries);
+
+            if (propertyKeyValuePair.Length != 2)
+            {
+                throw new ArgumentException($"Unexpected number of parameters in property {property}");
+            }
+
+            return new DatabaseProperty(propertyKeyValuePair[0], propertyKeyValuePair[1]);
+        }
+    }
+}

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -389,7 +389,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             return result;
         }
 
-        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName)
+        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName, bool includeCompositeObjects = false)
         {
             if (string.IsNullOrWhiteSpace(databaseName))
             {
@@ -402,7 +402,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             using var package = DacPackage.Load(dacpacFile.FullName);
             using var file = File.Create(Path.Combine(dacpacFile.DirectoryName, scriptFileName));
 
-            var options = new DacDeployOptions() { IncludeCompositeObjects = true };
+            var options = new DacDeployOptions() { IncludeCompositeObjects = includeCompositeObjects };
             DacServices.GenerateCreateScript(file, package, databaseName, options);
         }
     }

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -161,7 +161,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             EnsureModelCreated();
             EnsureModelValidated();
             EnsureMetadataCreated();
-
+            
             // Check if the file already exists
             if (outputFile.Exists)
             {
@@ -347,9 +347,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 stream.Write(buffer, 0, buffer.Length);
             }
         }
-
+        
         public bool TreatTSqlWarningsAsErrors { get; set; }
-
+        
         public void AddWarningsToSuppress(string suppressionList)
         {
             _suppressedWarnings.AddRange(ParseSuppressionList(suppressionList));
@@ -369,7 +369,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     list.AddRange(warningList.FindAll((x) => !list.Contains(x)));
                 }
             }
-
+                
         }
 
         private List<int> ParseSuppressionList(string suppressionList)

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -389,21 +389,20 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             return result;
         }
 
-        public void GenerateCreateScript(BuildOptions options)
+        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName, DacDeployOptions deployOptions)
         {
-            if (string.IsNullOrWhiteSpace(options.TargetDatabaseName))
+            if (string.IsNullOrWhiteSpace(databaseName))
             {
-                throw new ArgumentException("The database name is mandatory.", nameof(options.TargetDatabaseName));
+                throw new ArgumentException("The database name is mandatory.", nameof(databaseName));
             }
 
-            var scriptFileName = $"{options.TargetDatabaseName}_Create.sql";
+            var scriptFileName = $"{databaseName}_Create.sql";
             Console.WriteLine($"Generating create script {scriptFileName}");
 
-            using var package = DacPackage.Load(options.Output.FullName);
-            using var file = File.Create(Path.Combine(options.Output.DirectoryName, scriptFileName));
+            using var package = DacPackage.Load(dacpacFile.FullName);
+            using var file = File.Create(Path.Combine(dacpacFile.DirectoryName, scriptFileName));
 
-            var deployOptions = options.ToDacDeployOptions();
-            DacServices.GenerateCreateScript(file, package, options.TargetDatabaseName, deployOptions);
+            DacServices.GenerateCreateScript(file, package, databaseName, deployOptions);
         }
     }
 }

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -161,7 +161,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             EnsureModelCreated();
             EnsureModelValidated();
             EnsureMetadataCreated();
-            
+
             // Check if the file already exists
             if (outputFile.Exists)
             {
@@ -347,9 +347,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 stream.Write(buffer, 0, buffer.Length);
             }
         }
-        
+
         public bool TreatTSqlWarningsAsErrors { get; set; }
-        
+
         public void AddWarningsToSuppress(string suppressionList)
         {
             _suppressedWarnings.AddRange(ParseSuppressionList(suppressionList));
@@ -369,7 +369,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     list.AddRange(warningList.FindAll((x) => !list.Contains(x)));
                 }
             }
-                
+
         }
 
         private List<int> ParseSuppressionList(string suppressionList)
@@ -389,21 +389,21 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             return result;
         }
 
-        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName, bool includeCompositeObjects)
+        public void GenerateCreateScript(BuildOptions options)
         {
-            if (string.IsNullOrWhiteSpace(databaseName))
+            if (string.IsNullOrWhiteSpace(options.TargetDatabaseName))
             {
-                throw new ArgumentException("The database name is mandatory.", nameof(databaseName));
+                throw new ArgumentException("The database name is mandatory.", nameof(options.TargetDatabaseName));
             }
 
-            var scriptFileName = $"{databaseName}_Create.sql";
+            var scriptFileName = $"{options.TargetDatabaseName}_Create.sql";
             Console.WriteLine($"Generating create script {scriptFileName}");
 
-            using var package = DacPackage.Load(dacpacFile.FullName);
-            using var file = File.Create(Path.Combine(dacpacFile.DirectoryName, scriptFileName));
+            using var package = DacPackage.Load(options.Output.FullName);
+            using var file = File.Create(Path.Combine(options.Output.DirectoryName, scriptFileName));
 
-            var options = new DacDeployOptions() { IncludeCompositeObjects = includeCompositeObjects };
-            DacServices.GenerateCreateScript(file, package, databaseName, options);
+            var deployOptions = options.ToDacDeployOptions();
+            DacServices.GenerateCreateScript(file, package, options.TargetDatabaseName, deployOptions);
         }
     }
 }

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -389,7 +389,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             return result;
         }
 
-        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName, bool includeCompositeObjects = false)
+        public void GenerateCreateScript(FileInfo dacpacFile, string databaseName, bool includeCompositeObjects)
         {
             if (string.IsNullOrWhiteSpace(databaseName))
             {

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -161,7 +161,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             EnsureModelCreated();
             EnsureModelValidated();
             EnsureMetadataCreated();
-            
+
             // Check if the file already exists
             if (outputFile.Exists)
             {
@@ -347,9 +347,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 stream.Write(buffer, 0, buffer.Length);
             }
         }
-        
+
         public bool TreatTSqlWarningsAsErrors { get; set; }
-        
+
         public void AddWarningsToSuppress(string suppressionList)
         {
             _suppressedWarnings.AddRange(ParseSuppressionList(suppressionList));
@@ -369,7 +369,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     list.AddRange(warningList.FindAll((x) => !list.Contains(x)));
                 }
             }
-                
+
         }
 
         private List<int> ParseSuppressionList(string suppressionList)
@@ -401,7 +401,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             using var package = DacPackage.Load(dacpacFile.FullName);
             using var file = File.Create(Path.Combine(dacpacFile.DirectoryName, scriptFileName));
-            DacServices.GenerateCreateScript(file, package, databaseName);
+
+            var options = new DacDeployOptions() { IncludeCompositeObjects = true };
+            DacServices.GenerateCreateScript(file, package, databaseName, options);
         }
     }
 }

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -193,36 +193,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public void SetDeployProperty(string deployProperty)
             => this.SetDeployProperties(new[] { deployProperty });
 
-        public void SetDeployProperties(string[] deployProperties)
-        {
-            foreach (var deployProperty in deployProperties)
-            {
-                var databaseProperty = DatabaseProperty.Create(deployProperty);
-
-                if (databaseProperty.Name == "SqlCommandVariableValues")
-                {
-                    throw new ArgumentException("SQLCMD variables should be set using the --sqlcmdvar command line argument and not as a property.");
-                }
-
-                try
-                {
-                    var propertyValue = this.DeployOptions.SetDeployProperty(databaseProperty.Name, databaseProperty.Value);
-
-                    var parsedValue = propertyValue switch
-                    {
-                        ObjectType[] o => string.Join(',', o),
-                        DacAzureDatabaseSpecification s => $"{s.Edition},{s.MaximumSize},{s.ServiceObjective}",
-                        _ => propertyValue == null ? "null" : propertyValue.ToString()
-                    };
-
-                    _console.WriteLine($"Setting property {databaseProperty.Name} to value {parsedValue}");
-                }
-                catch (FormatException)
-                {
-                    throw new ArgumentException($@"Unable to parse value for property with name {databaseProperty.Name}: {databaseProperty.Value}", nameof(databaseProperty.Value));
-                }
-            }
-        }
+        public void SetDeployProperties(string[] deployProperties) => this.DeployOptions.SetDeployProperties(deployProperties, _console);
 
         private void EnsureConnectionStringComplete()
         {

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlServer.Dac.Model;
@@ -192,118 +190,37 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             }
         }
 
-        public void SetProperty(string key, string value)
+        public void SetDeployProperty(string deployProperty)
+            => this.SetDeployProperties(new[] { deployProperty });
+
+        public void SetDeployProperties(string[] deployProperties)
         {
-            try
+            foreach (var deployProperty in deployProperties)
             {
-                // Convert value into the appropriate type depending on the key
-                object propertyValue = key switch
+                var databaseProperty = DatabaseProperty.Create(deployProperty);
+
+                if (databaseProperty.Name == "SqlCommandVariableValues")
                 {
-                    "AdditionalDeploymentContributorArguments" => value,
-                    "AdditionalDeploymentContributorPaths" => value,
-                    "AdditionalDeploymentContributors" => value,
-                    "AllowDropBlockingAssemblies" => bool.Parse(value),
-                    "AllowIncompatiblePlatform" => bool.Parse(value),
-                    "AllowUnsafeRowLevelSecurityDataMovement" => bool.Parse(value),
-                    "BackupDatabaseBeforeChanges" => bool.Parse(value),
-                    "BlockOnPossibleDataLoss" => bool.Parse(value),
-                    "BlockWhenDriftDetected" => bool.Parse(value),
-                    "CommandTimeout" => int.Parse(value),
-                    "CommentOutSetVarDeclarations" => bool.Parse(value),
-                    "CompareUsingTargetCollation" => bool.Parse(value),
-                    "CreateNewDatabase" => bool.Parse(value),
-                    "DatabaseLockTimeout" => int.Parse(value),
-                    "DatabaseSpecification" => PropertyParser.ParseDatabaseSpecification(value),
-                    "DeployDatabaseInSingleUserMode" => bool.Parse(value),
-                    "DisableAndReenableDdlTriggers" => bool.Parse(value),
-                    "DoNotAlterChangeDataCaptureObjects" => bool.Parse(value),
-                    "DoNotAlterReplicatedObjects" => bool.Parse(value),
-                    "DoNotDropObjectTypes" => PropertyParser.ParseObjectTypes(value),
-                    "DropConstraintsNotInSource" => bool.Parse(value),
-                    "DropDmlTriggersNotInSource" => bool.Parse(value),
-                    "DropExtendedPropertiesNotInSource" => bool.Parse(value),
-                    "DropIndexesNotInSource" => bool.Parse(value),
-                    "DropObjectsNotInSource" => bool.Parse(value),
-                    "DropPermissionsNotInSource" => bool.Parse(value),
-                    "DropRoleMembersNotInSource" => bool.Parse(value),
-                    "DropStatisticsNotInSource" => bool.Parse(value),
-                    "ExcludeObjectTypes" => PropertyParser.ParseObjectTypes(value),
-                    "GenerateSmartDefaults" => bool.Parse(value),
-                    "IgnoreAnsiNulls" => bool.Parse(value),
-                    "IgnoreAuthorizer" => bool.Parse(value),
-                    "IgnoreColumnCollation" => bool.Parse(value),
-                    "IgnoreColumnOrder" => bool.Parse(value),
-                    "IgnoreComments" => bool.Parse(value),
-                    "IgnoreCryptographicProviderFilePath" => bool.Parse(value),
-                    "IgnoreDdlTriggerOrder" => bool.Parse(value),
-                    "IgnoreDdlTriggerState" => bool.Parse(value),
-                    "IgnoreDefaultSchema" => bool.Parse(value),
-                    "IgnoreDmlTriggerOrder" => bool.Parse(value),
-                    "IgnoreDmlTriggerState" => bool.Parse(value),
-                    "IgnoreExtendedProperties" => bool.Parse(value),
-                    "IgnoreFileAndLogFilePath" => bool.Parse(value),
-                    "IgnoreFilegroupPlacement" => bool.Parse(value),
-                    "IgnoreFileSize" => bool.Parse(value),
-                    "IgnoreFillFactor" => bool.Parse(value),
-                    "IgnoreFullTextCatalogFilePath" => bool.Parse(value),
-                    "IgnoreIdentitySeed" => bool.Parse(value),
-                    "IgnoreIncrement" => bool.Parse(value),
-                    "IgnoreIndexOptions" => bool.Parse(value),
-                    "IgnoreIndexPadding" => bool.Parse(value),
-                    "IgnoreKeywordCasing" => bool.Parse(value),
-                    "IgnoreLockHintsOnIndexes" => bool.Parse(value),
-                    "IgnoreLoginSids" => bool.Parse(value),
-                    "IgnoreNotForReplication" => bool.Parse(value),
-                    "IgnoreObjectPlacementOnPartitionScheme" => bool.Parse(value),
-                    "IgnorePartitionSchemes" => bool.Parse(value),
-                    "IgnorePermissions" => bool.Parse(value),
-                    "IgnoreQuotedIdentifiers" => bool.Parse(value),
-                    "IgnoreRoleMembership" => bool.Parse(value),
-                    "IgnoreRouteLifetime" => bool.Parse(value),
-                    "IgnoreSemicolonBetweenStatements" => bool.Parse(value),
-                    "IgnoreTableOptions" => bool.Parse(value),
-                    "IgnoreTablePartitionOptions" => bool.Parse(value),
-                    "IgnoreUserSettingsObjects" => bool.Parse(value),
-                    "IgnoreWhitespace" => bool.Parse(value),
-                    "IgnoreWithNocheckOnCheckConstraints" => bool.Parse(value),
-                    "IgnoreWithNocheckOnForeignKeys" => bool.Parse(value),
-                    "IncludeCompositeObjects" => bool.Parse(value),
-                    "IncludeTransactionalScripts" => bool.Parse(value),
-                    "LongRunningCommandTimeout" => int.Parse(value),
-                    "NoAlterStatementsToChangeClrTypes" => bool.Parse(value),
-                    "PopulateFilesOnFileGroups" => bool.Parse(value),
-                    "RegisterDataTierApplication" => bool.Parse(value),
-                    "RunDeploymentPlanExecutors" => bool.Parse(value),
-                    "ScriptDatabaseCollation" => bool.Parse(value),
-                    "ScriptDatabaseCompatibility" => bool.Parse(value),
-                    "ScriptDatabaseOptions" => bool.Parse(value),
-                    "ScriptDeployStateChecks" => bool.Parse(value),
-                    "ScriptFileSize" => bool.Parse(value),
-                    "ScriptNewConstraintValidation" => bool.Parse(value),
-                    "ScriptRefreshModule" => bool.Parse(value),
-                    "SqlCommandVariableValues" => throw new ArgumentException("SQLCMD variables should be set using the --sqlcmdvar command line argument and not as a property."),
-                    "TreatVerificationErrorsAsWarnings" => bool.Parse(value),
-                    "UnmodifiableObjectWarnings" => bool.Parse(value),
-                    "VerifyCollationCompatibility" => bool.Parse(value),
-                    "VerifyDeployment" => bool.Parse(value),
-                    _ => throw new ArgumentException($"Unknown property with name {key}", nameof(key))
-                };
+                    throw new ArgumentException("SQLCMD variables should be set using the --sqlcmdvar command line argument and not as a property.");
+                }
 
-                PropertyInfo property = typeof(DacDeployOptions).GetProperty(key, BindingFlags.Public | BindingFlags.Instance);
-                property.SetValue(DeployOptions, propertyValue);
-
-                var parsedValue = propertyValue switch
+                try
                 {
-                    ObjectType[] o => string.Join(',', o),
-                    DacAzureDatabaseSpecification s => $"{s.Edition},{s.MaximumSize},{s.ServiceObjective}",
-                    _ => propertyValue.ToString()
-                };
+                    var propertyValue = this.DeployOptions.SetDeployProperty(databaseProperty.Name, databaseProperty.Value);
 
-                _console.WriteLine($"Setting property {key} to value {parsedValue}");
-            }
-            catch (FormatException)
-            {
-                throw new ArgumentException($"Unable to parse value for property with name {key}: {value}", nameof(value));
+                    var parsedValue = propertyValue switch
+                    {
+                        ObjectType[] o => string.Join(',', o),
+                        DacAzureDatabaseSpecification s => $"{s.Edition},{s.MaximumSize},{s.ServiceObjective}",
+                        _ => propertyValue == null ? "null" : propertyValue.ToString()
+                    };
+
+                    _console.WriteLine($"Setting property {databaseProperty.Name} to value {parsedValue}");
+                }
+                catch (FormatException)
+                {
+                    throw new ArgumentException($@"Unable to parse value for property with name {databaseProperty.Name}: {databaseProperty.Value}", nameof(databaseProperty.Value));
+                }
             }
         }
 

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -26,6 +26,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<FileInfo>(new string[] { "--postdeploy" }, "Filename of optional post-deployment script"),
                 new Option<FileInfo>(new string[] { "--refactorlog" }, "Filename of optional refactor log script"),
                 new Option<string[]>(new string[] { "--property", "-p" }, "Properties to be set on the model"),
+                new Option<string[]>(new string[] { "--createscriptproperty", "-cp" }, "Properties to be set for the create script"),
                 new Option<string[]>(new string[] { "--sqlcmdvar", "-sc" }, "SqlCmdVariable(s) to include"),
 
                 new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
@@ -174,7 +175,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             if (options.GenerateCreateScript)
             {
-                packageBuilder.GenerateCreateScript(options.Output, options.TargetDatabaseName ?? options.Name, options.IncludeCompositeObjects);
+                packageBuilder.GenerateCreateScript(options);
             }
 
             return 0;

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -217,11 +217,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
                 if (options.Property != null)
                 {
-                    foreach (var propertyValue in options.Property)
-                    {
-                        string[] keyValuePair = propertyValue.Split('=', 2);
-                        deployer.SetProperty(keyValuePair[0], keyValuePair[1]);
-                    }
+                    deployer.SetDeployProperties(options.Property);
                 }
 
                 if (options.SqlCmdVar != null)

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -175,7 +175,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             if (options.GenerateCreateScript)
             {
-                var deployOptions = options.ToDacDeployOptions();
+                var deployOptions = options.ExtractDeployOptions();
                 packageBuilder.GenerateCreateScript(options.Output, options.TargetDatabaseName ?? options.Name, deployOptions);
             }
 

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -30,6 +30,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
                 new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
                 new Option<bool>(new string[] { "--generatecreatescript", "-gcs" }, "Generate create script for package"),
+                new Option<bool>(new string[] { "--includeCompositeObjects", "-ico" }, "Include referenced, external elements that also compose the source model"),
                 new Option<string>(new string[] { "--targetdatabasename", "-tdn" }, "Name of the database to use in the generated create script"),
                 new Option<string>(new string[] { "--suppresswarnings", "-spw" }, "Warning(s) to suppress"),
                 new Option<FileInfo>(new string[] { "--suppresswarningslistfile", "-spl" }, "Filename for warning(s) to suppress for particular files"),
@@ -128,7 +129,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                         packageBuilder.AddInputFile(inputFile);
                     }
                 }
-                else 
+                else
                 {
                     throw new ArgumentException($"No input files found, missing {options.InputFile.Name}");
                 }
@@ -173,7 +174,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             if (options.GenerateCreateScript)
             {
-                packageBuilder.GenerateCreateScript(options.Output, options.TargetDatabaseName ?? options.Name);
+                packageBuilder.GenerateCreateScript(options.Output, options.TargetDatabaseName ?? options.Name, options.IncludeCompositeObjects);
             }
 
             return 0;
@@ -184,7 +185,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             var scriptInspector = new ScriptInspector();
 
             // Add predeployment and postdeployment scripts
-            if (options.PreDeploy != null) 
+            if (options.PreDeploy != null)
             {
                 scriptInspector.AddPreDeploymentScript(options.PreDeploy);
             }
@@ -238,7 +239,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 {
                     deployer.UseTargetServer(options.TargetServerName);
                 }
-                
+
                 if (!string.IsNullOrWhiteSpace(options.TargetUser))
                 {
                     deployer.UseSqlAuthentication(options.TargetUser, options.TargetPassword);

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -30,7 +30,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
                 new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
                 new Option<bool>(new string[] { "--generatecreatescript", "-gcs" }, "Generate create script for package"),
-                new Option<bool>(new string[] { "--includeCompositeObjects", "-ico" }, "Include referenced, external elements that also compose the source model"),
+                new Option<bool>(new string[] { "--includecompositeobjects", "-ico" }, "Include referenced, external elements that also compose the source model"),
                 new Option<string>(new string[] { "--targetdatabasename", "-tdn" }, "Name of the database to use in the generated create script"),
                 new Option<string>(new string[] { "--suppresswarnings", "-spw" }, "Warning(s) to suppress"),
                 new Option<FileInfo>(new string[] { "--suppresswarningslistfile", "-spl" }, "Filename for warning(s) to suppress for particular files"),

--- a/src/DacpacTool/Program.cs
+++ b/src/DacpacTool/Program.cs
@@ -25,8 +25,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 new Option<FileInfo>(new string[] { "--predeploy" }, "Filename of optional pre-deployment script"),
                 new Option<FileInfo>(new string[] { "--postdeploy" }, "Filename of optional post-deployment script"),
                 new Option<FileInfo>(new string[] { "--refactorlog" }, "Filename of optional refactor log script"),
-                new Option<string[]>(new string[] { "--property", "-p" }, "Properties to be set on the model"),
-                new Option<string[]>(new string[] { "--createscriptproperty", "-cp" }, "Properties to be set for the create script"),
+                new Option<string[]>(new string[] { "--buildproperty", "-bp" }, "Build properties to be set on the model"),
+                new Option<string[]>(new string[] { "--deployproperty", "-dp" }, "Deploy properties to be set for the create script"),
                 new Option<string[]>(new string[] { "--sqlcmdvar", "-sc" }, "SqlCmdVariable(s) to include"),
 
                 new Option<bool>(new string[] { "--warnaserror" }, "Treat T-SQL Warnings As Errors"),
@@ -84,9 +84,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             packageBuilder.SetMetadata(options.Name, options.Version);
 
             // Set properties on the model (if defined)
-            if (options.Property != null)
+            if (options.BuildProperty != null)
             {
-                foreach (var propertyValue in options.Property)
+                foreach (var propertyValue in options.BuildProperty)
                 {
                     string[] keyValuePair = propertyValue.Split('=', 2);
                     packageBuilder.SetProperty(keyValuePair[0], keyValuePair[1]);
@@ -175,7 +175,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
             if (options.GenerateCreateScript)
             {
-                packageBuilder.GenerateCreateScript(options);
+                var deployOptions = options.ToDacDeployOptions();
+                packageBuilder.GenerateCreateScript(options.Output, options.TargetDatabaseName ?? options.Name, deployOptions);
             }
 
             return 0;

--- a/src/DacpacTool/PropertyParser.cs
+++ b/src/DacpacTool/PropertyParser.cs
@@ -23,11 +23,11 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         }
 
         /// <summary>
-        /// Converts the <see cref="BuildOptions"/> to a <see cref="DacDeployOptions"/> object with all properties
+        /// Extracts a <see cref="DacDeployOptions"/> from the <see cref="BuildOptions"/>
         /// </summary>
         /// <param name="options">The build options</param>
         /// <returns>The <see cref="DacDeployOptions"/> object</returns>
-        public static DacDeployOptions ToDacDeployOptions(this BuildOptions options)
+        public static DacDeployOptions ExtractDeployOptions(this BuildOptions options)
         {
             var deployOptions = new DacDeployOptions();
 

--- a/src/DacpacTool/PropertyParser.cs
+++ b/src/DacpacTool/PropertyParser.cs
@@ -31,7 +31,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         {
             var deployOptions = new DacDeployOptions();
 
-            if (options.Property != null)
+            if (options.CreateScriptProperty != null)
             {
                 foreach (var buildProperty in options.CreateScriptProperty.Where(p => string.IsNullOrWhiteSpace(p) == false))
                 {

--- a/src/DacpacTool/PropertyParser.cs
+++ b/src/DacpacTool/PropertyParser.cs
@@ -1,0 +1,160 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using Microsoft.SqlServer.Dac;
+
+namespace MSBuild.Sdk.SqlProj.DacpacTool
+{
+    /// <summary>
+    /// Allows to parse properties from build or deploy options
+    /// </summary>
+    public static class PropertyParser
+    {
+        private static readonly IDictionary<string, Func<string, object>> CustomParsers = new Dictionary<string, Func<string, object>>();
+
+        static PropertyParser()
+        {
+            CustomParsers.Add("DoNotDropObjectTypes", ParseObjectTypes);
+            CustomParsers.Add("ExcludeObjectTypes", ParseObjectTypes);
+            CustomParsers.Add("DatabaseSpecification", ParseDatabaseSpecification);
+        }
+
+        /// <summary>
+        /// Converts the <see cref="BuildOptions"/> to a <see cref="DacDeployOptions"/> object with all properties
+        /// </summary>
+        /// <param name="options">The build options</param>
+        /// <returns>The <see cref="DacDeployOptions"/> object</returns>
+        public static DacDeployOptions ToDacDeployOptions(this BuildOptions options)
+        {
+            var deployOptions = new DacDeployOptions();
+
+            if (options.Property != null)
+            {
+                foreach (var buildProperty in options.CreateScriptProperty.Where(p => string.IsNullOrWhiteSpace(p) == false))
+                {
+                    object propertyValue;
+                    var databaseProperty = DatabaseProperty.Create(buildProperty);
+
+                    var property = typeof(DacDeployOptions).GetProperties().SingleOrDefault(p => string.Compare(p.Name, databaseProperty.Name, StringComparison.OrdinalIgnoreCase) == 0);
+
+                    if (property == null)
+                    {
+                        continue;
+                    }
+
+                    if (CustomParsers.TryGetValue(databaseProperty.Name, out var parser))
+                    {
+                        propertyValue = parser.Invoke(databaseProperty.Value);
+                    }
+                    else
+                    {
+                        propertyValue =  StringToTypedValue(databaseProperty.Value, property.PropertyType);
+                    }
+
+                    if (propertyValue != null)
+                    {
+                        property.SetValue(deployOptions, propertyValue);
+                    }
+                }
+            }
+
+            return deployOptions;
+        }
+
+        public static ObjectType[] ParseObjectTypes(string value)
+        {
+            if (value.Contains(';', StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Expected object types to be comma-seperated instead of semi-colon separated");
+            }
+
+            var objectTypes = value.Split(',');
+            var result = new ObjectType[objectTypes.Length];
+
+            for (int i = 0; i < objectTypes.Length; i++)
+            {
+                if (!Enum.TryParse(objectTypes[i], false, out ObjectType objectType))
+                {
+                    throw new ArgumentException($"Unknown object type {objectTypes[i]} specified.", nameof(value));
+                }
+
+                result[i] = objectType;
+            }
+
+            return result;
+        }
+
+        public static DacAzureDatabaseSpecification ParseDatabaseSpecification(string value)
+        {
+            if (value.Contains(';', StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Expected database specification to be comma-seperated instead of semi-colon separated");
+            }
+
+            var specification = value.Split(",", 3);
+            if (specification.Length != 3)
+            {
+                throw new ArgumentException("Expected at least 3 parameters for DatabaseSpecification; Edition, MaximumSize and ServiceObjective", nameof(value));
+            }
+
+            if (!Enum.TryParse(specification[0], false, out DacAzureEdition edition))
+            {
+                throw new ArgumentException($"Unknown edition '{specification[0]}' specified.", nameof(value));
+            }
+
+            if (!int.TryParse(specification[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int maximumSize))
+            {
+                throw new ArgumentException($"Unable to parse maximum size '{specification[1]}' as an integer.", nameof(value));
+            }
+
+            return new DacAzureDatabaseSpecification
+            {
+                Edition = edition,
+                MaximumSize = maximumSize,
+                ServiceObjective = specification[2]
+            };
+        }
+
+        private static object StringToTypedValue(string stringValue, Type targetType)
+        {
+            object result = null;
+
+            var converter = TypeDescriptor.GetConverter(targetType);
+
+            if (converter.CanConvertFrom(typeof(string)))
+            {
+                result = converter.ConvertFromString(null, CultureInfo.InvariantCulture, stringValue);
+            }
+
+            return result;
+        }
+
+        private class DatabaseProperty
+        {
+            private DatabaseProperty(string name, string value)
+            {
+                this.Name = name;
+                this.Value = value;
+            }
+
+            public string Name { get; }
+
+            public string Value { get; }
+
+            public static DatabaseProperty Create(string property)
+            {
+                var propertyKeyValuePair = property.Split('=', 2, StringSplitOptions.RemoveEmptyEntries);
+
+                if (propertyKeyValuePair.Length != 2)
+                {
+                    throw new ArgumentException($"Unexpected number of parameters in property {property}");
+                }
+
+                return new DatabaseProperty(propertyKeyValuePair[0], propertyKeyValuePair[1]);
+            }
+        }
+    }
+}

--- a/src/DacpacTool/PropertyParser.cs
+++ b/src/DacpacTool/PropertyParser.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -31,9 +30,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         {
             var deployOptions = new DacDeployOptions();
 
-            if (options.CreateScriptProperty != null)
+            if (options.DeployProperty != null)
             {
-                foreach (var buildProperty in options.CreateScriptProperty.Where(p => string.IsNullOrWhiteSpace(p) == false))
+                foreach (var buildProperty in options.DeployProperty.Where(p => string.IsNullOrWhiteSpace(p) == false))
                 {
                     object propertyValue;
                     var databaseProperty = DatabaseProperty.Create(buildProperty);

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -184,6 +184,12 @@
         <PropertyValue>$(%(_PropertyNames.Identity))</PropertyValue>
       </PropertyNames>
 
+      <!-- Get the values for known properties to be used in the create script -->
+     <_CreateScriptPropertyNames Include="$(KnownDeployProperties)" />
+     <CreateScriptPropertyNames Include="@(_CreateScriptPropertyNames)" Condition=" '$(%(Identity))' != '' ">
+       <PropertyValue>$(%(_CreateScriptPropertyNames.Identity))</PropertyValue>
+     </CreateScriptPropertyNames>
+
       <!-- Compile the list of references -->
       <IncludedDacpacReferenceFiles Include="@(DacpacReference->'%(DacpacFile)')" />
     </ItemGroup>
@@ -212,6 +218,7 @@
       <ReferenceArguments>@(DacpacReference->'-r &quot;%(DacpacFile);%(ExternalParts)&quot;', ' ')</ReferenceArguments>
       <InputFileArguments>-i &quot;$(IntermediateOutputPath)$(MSBuildProjectName).InputFiles.txt&quot;</InputFileArguments>
       <PropertyArguments>@(PropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
+      <GenerateScriptPropertyArguments>@(CreateScriptPropertyNames->'-cp %(Identity)=%(PropertyValue)', ' ')</GenerateScriptPropertyArguments>
       <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)', ' ')</SqlCmdVariableArguments>
       <PreDeploymentScriptArgument>@(PreDeploy->'--predeploy %(Identity)', ' ')</PreDeploymentScriptArgument>
       <PostDeploymentScriptArgument>@(PostDeploy->'--postdeploy %(Identity)', ' ')</PostDeploymentScriptArgument>
@@ -219,11 +226,10 @@
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
       <TreatTSqlWarningsAsErrorsArgument Condition="'$(TreatTSqlWarningsAsErrors)' == 'True' Or ('$(TreatWarningsAsErrors)' == 'True' And '$(TreatTSqlWarningsAsErrors)' == '')">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
       <GenerateCreateScriptArgument Condition="'$(GenerateCreateScript)' == 'True'">--generatecreatescript</GenerateCreateScriptArgument>
-      <IncludeCompositeObjectsArgument Condition="'$(IncludeCompositeObjects)' == 'True'">--includecompositeobjects</IncludeCompositeObjectsArgument>
       <TargetDatabaseNameArgument Condition="'$(TargetDatabaseName)' != '$(MSBuildProjectName)'">-tdn &quot;$(TargetDatabaseName)&quot;</TargetDatabaseNameArgument>
       <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">-spw &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
       <WarningsSuppressionListArgument Condition="'@(WarningsSuppressionFiles->'%(Identity)')'!=''">-spl &quot;$(IntermediateOutputPath)$(MSBuildProjectName).WarningsSuppression.txt&quot;</WarningsSuppressionListArgument>
-      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument) $(IncludeCompositeObjectsArgument)</DacpacToolCommand>
+      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(GenerateScriptPropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument)</DacpacToolCommand>
     </PropertyGroup>
     <!-- Run it, except during design-time builds -->
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -179,16 +179,16 @@
           Inputs="@(Content);@(PreDeploy);@(PostDeploy);@(RefactorLog);$(IncludedFiles);$(ProjectPath)" Outputs="$(TargetPath)">
     <ItemGroup>
       <!-- Get the values for known model properties specified in the project file -->
-      <_PropertyNames Include="$(KnownModelProperties)" />
-      <PropertyNames Include="@(_PropertyNames)" Condition=" '$(%(Identity))' != '' ">
-        <PropertyValue>$(%(_PropertyNames.Identity))</PropertyValue>
-      </PropertyNames>
+      <_BuildPropertyNames Include="$(KnownModelProperties)" />
+      <BuildPropertyNames Include="@(_BuildPropertyNames)" Condition=" '$(%(Identity))' != '' ">
+        <PropertyValue>$(%(_BuildPropertyNames.Identity))</PropertyValue>
+      </BuildPropertyNames>
 
       <!-- Get the values for known properties to be used in the create script -->
-     <_CreateScriptPropertyNames Include="$(KnownDeployProperties)" />
-     <CreateScriptPropertyNames Include="@(_CreateScriptPropertyNames)" Condition=" '$(%(Identity))' != '' ">
-       <PropertyValue>$(%(_CreateScriptPropertyNames.Identity))</PropertyValue>
-     </CreateScriptPropertyNames>
+     <_DeployPropertyNames Include="$(KnownDeployProperties)" />
+     <DeployPropertyNames Include="@(_DeployPropertyNames)" Condition=" '$(%(Identity))' != '' ">
+       <PropertyValue>$(%(_DeployPropertyNames.Identity))</PropertyValue>
+     </DeployPropertyNames>
 
       <!-- Compile the list of references -->
       <IncludedDacpacReferenceFiles Include="@(DacpacReference->'%(DacpacFile)')" />
@@ -217,8 +217,8 @@
       <SqlServerVersionArgument>-sv $(SqlServerVersion)</SqlServerVersionArgument>
       <ReferenceArguments>@(DacpacReference->'-r &quot;%(DacpacFile);%(ExternalParts)&quot;', ' ')</ReferenceArguments>
       <InputFileArguments>-i &quot;$(IntermediateOutputPath)$(MSBuildProjectName).InputFiles.txt&quot;</InputFileArguments>
-      <PropertyArguments>@(PropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
-      <GenerateScriptPropertyArguments>@(CreateScriptPropertyNames->'-cp %(Identity)=%(PropertyValue)', ' ')</GenerateScriptPropertyArguments>
+      <BuildPropertyArguments>@(BuildPropertyNames->'-bp %(Identity)=%(PropertyValue)', ' ')</BuildPropertyArguments>
+      <DeployPropertyArguments>@(DeployPropertyNames->'-dp %(Identity)=%(PropertyValue)', ' ')</DeployPropertyArguments>
       <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)', ' ')</SqlCmdVariableArguments>
       <PreDeploymentScriptArgument>@(PreDeploy->'--predeploy %(Identity)', ' ')</PreDeploymentScriptArgument>
       <PostDeploymentScriptArgument>@(PostDeploy->'--postdeploy %(Identity)', ' ')</PostDeploymentScriptArgument>
@@ -229,7 +229,7 @@
       <TargetDatabaseNameArgument Condition="'$(TargetDatabaseName)' != '$(MSBuildProjectName)'">-tdn &quot;$(TargetDatabaseName)&quot;</TargetDatabaseNameArgument>
       <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">-spw &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
       <WarningsSuppressionListArgument Condition="'@(WarningsSuppressionFiles->'%(Identity)')'!=''">-spl &quot;$(IntermediateOutputPath)$(MSBuildProjectName).WarningsSuppression.txt&quot;</WarningsSuppressionListArgument>
-      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(GenerateScriptPropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument)</DacpacToolCommand>
+      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(BuildPropertyArguments) $(DeployPropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument)</DacpacToolCommand>
     </PropertyGroup>
     <!-- Run it, except during design-time builds -->
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -8,7 +8,7 @@
   <!--
     Set LanguageTargets to Microsoft.Common.targets for any project that the SDK won't (.proj, .noproj, etc)
     https://github.com/dotnet/sdk/blob/50ddfbb91be94d068514e8f4b0ce1052156364a0/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L28
-    
+
     We can't default LanguageTargets it is set in the SDK and immediately imported.  So we can only default
     it if we know the SDK won't.  Projects probably won't load in Visual Studio but will build from the
     command-line just fine.
@@ -21,7 +21,7 @@
   <Import Project="$(CustomBeforeNoTargets)" Condition="'$(CustomBeforeNoTargets)' != '' and Exists('$(CustomBeforeNoTargets)')" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
-  
+
   <ItemGroup>
     <!-- Override primary output path to be a .dacpac -->
     <_IntermediateAssembly Include="@(IntermediateAssembly)" />
@@ -73,12 +73,12 @@
   <Target Name="ComputeIntermediateSatelliteAssemblies" />
 
   <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets" 
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets"
           Condition="'$(DebuggerFlavor)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')" />
 
   <Import Project="$(CustomAfterNoTargets)" Condition="'$(CustomAfterNoTargets)' != '' and Exists('$(CustomAfterNoTargets)')" />
 
-  <!-- 
+  <!--
     Microsoft.Managed.Targets is imported by the managed language target files in MSBuild 16.0 and above, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
     So import it when the managed targets do not get imported.
   -->
@@ -105,14 +105,14 @@
     location of the package and then checking if a that package contains a .dacpac file inside of the tools folder.
   -->
   <Target Name="ResolveDatabaseReferences">
-    <ItemGroup> 
+    <ItemGroup>
       <!-- Resolve all package references to their physical location first -->
       <_ResolvedPackageReference Include="%(PackageReference.Identity)">
         <!-- Determine technical name of package (ie. Foo.Bar.Database -> Foo_Bar_Database) -->
         <PackageName>@(PackageReference->'%(Identity)'->Replace('.', '_'))</PackageName>
         <!-- Prepend Pkg to technical name from above and resolve variable (ie. Foo_Bar_Database -> %home%\.nuget\packages\foo.bar.database\<version> -->
         <PhysicalLocation>$(Pkg%(_ResolvedPackageReference.PackageName))</PhysicalLocation>
-        <!-- 
+        <!--
           If no Pkg<package-id> property is available, fall back to deriving the physical location from several other properties.
           This isn't guaranteed to be correct, particularly when floating versions are used, but will successfully resolve most of the time.
         -->
@@ -131,7 +131,7 @@
         <!-- Constructs variable to make external parts -->
         <ExternalParts>dbl=%(_ResolvedProjectReferencePaths.DatabaseVariableLiteralValue)|dbv=%(_ResolvedProjectReferencePaths.DatabaseSqlCmdVariable)|srv=%(_ResolvedProjectReferencePaths.ServerSqlCmdVariable)</ExternalParts>
       </_ResolvedProjectReference>
-    
+
       <!-- Build a list of package/project references that include a dacpac file matching the package identity in their tools folder -->
       <DacpacReference Include="@(_ResolvedPackageReference);@(_ResolvedProjectReference)" Condition="Exists(%(DacpacFile))" />
     </ItemGroup>
@@ -175,7 +175,7 @@
   <!--
     Performs the actual compilation of the input files (*.sql) into a .dacpac package by calling into a command line tool to do the actual work.
   -->
-  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabaseReferences;GetIncludedFiles" 
+  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabaseReferences;GetIncludedFiles"
           Inputs="@(Content);@(PreDeploy);@(PostDeploy);@(RefactorLog);$(IncludedFiles);$(ProjectPath)" Outputs="$(TargetPath)">
     <ItemGroup>
       <!-- Get the values for known model properties specified in the project file -->
@@ -183,7 +183,7 @@
       <PropertyNames Include="@(_PropertyNames)" Condition=" '$(%(Identity))' != '' ">
         <PropertyValue>$(%(_PropertyNames.Identity))</PropertyValue>
       </PropertyNames>
-      
+
       <!-- Compile the list of references -->
       <IncludedDacpacReferenceFiles Include="@(DacpacReference->'%(DacpacFile)')" />
     </ItemGroup>
@@ -199,7 +199,7 @@
       <!-- Build a list of particular files with T-SQL warning suppression -->
       <WarningsSuppressionFiles Include="@(Content->'%(Identity)|%(SuppressTSqlWarnings)')" Condition="'%(Content.SuppressTSqlWarnings)' != ''"/>
     </ItemGroup>
-    <WriteLinesToFile 
+    <WriteLinesToFile
       File="$(IntermediateOutputPath)$(MSBuildProjectName).WarningsSuppression.txt"
       Overwrite="true"
       Lines="@(WarningsSuppressionFiles)" />
@@ -219,10 +219,11 @@
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
       <TreatTSqlWarningsAsErrorsArgument Condition="'$(TreatTSqlWarningsAsErrors)' == 'True' Or ('$(TreatWarningsAsErrors)' == 'True' And '$(TreatTSqlWarningsAsErrors)' == '')">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
       <GenerateCreateScriptArgument Condition="'$(GenerateCreateScript)' == 'True'">--generatecreatescript</GenerateCreateScriptArgument>
+      <IncludeCompositeObjectsArgument Condition="'$(IncludeCompositeObjects)' == 'True'">--includecompositeobjects</IncludeCompositeObjectsArgument>
       <TargetDatabaseNameArgument Condition="'$(TargetDatabaseName)' != '$(MSBuildProjectName)'">-tdn &quot;$(TargetDatabaseName)&quot;</TargetDatabaseNameArgument>
       <SuppressTSqlWarningsArgument Condition="'$(SuppressTSqlWarnings)'!=''">-spw &quot;$(SuppressTSqlWarnings)&quot;</SuppressTSqlWarningsArgument>
       <WarningsSuppressionListArgument Condition="'@(WarningsSuppressionFiles->'%(Identity)')'!=''">-spl &quot;$(IntermediateOutputPath)$(MSBuildProjectName).WarningsSuppression.txt&quot;</WarningsSuppressionListArgument>
-      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument)</DacpacToolCommand>
+      <DacpacToolCommand>dotnet &quot;$(DacpacToolExe)&quot; build $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments) $(PreDeploymentScriptArgument) $(PostDeploymentScriptArgument) $(RefactorLogScriptArgument) $(TreatTSqlWarningsAsErrorsArgument) $(SuppressTSqlWarningsArgument) $(WarningsSuppressionListArgument) $(DebugArgument) $(GenerateCreateScriptArgument) $(TargetDatabaseNameArgument) $(IncludeCompositeObjectsArgument)</DacpacToolCommand>
     </PropertyGroup>
     <!-- Run it, except during design-time builds -->
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />
@@ -280,7 +281,7 @@
     <Message Importance="Low" Text="Running command: $(DacpacToolCommand)" />
     <Exec Command="$(DacpacToolCommand)" />
   </Target>
-  
+
   <!-- Lists all dacpac files of interest to the current project, so that a referencing class library can copy these to its output directory -->
   <Target Name="CopyDacpacs" BeforeTargets="GetCopyToOutputDirectoryItems">
     <ItemGroup>

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -569,13 +569,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             packageBuilder.SetMetadata(packageName, "1.0.0.0");
             packageBuilder.ValidateModel();
 
-            var options = new BuildOptions();
-            options.TargetDatabaseName = packageName;
-            options.Output = tempFile;
-
             // Act
             packageBuilder.SaveToDisk(tempFile);
-            packageBuilder.GenerateCreateScript(options);
+            packageBuilder.GenerateCreateScript(tempFile, packageName, new DacDeployOptions());
 
             // Assert
             File.Exists(Path.Combine(tempFile.DirectoryName, $"{packageName}_Create.sql")).ShouldBeTrue();
@@ -610,18 +606,16 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             packageBuilder.AddReference(secondReference);
             packageBuilder.ValidateModel();
 
-            var buildOptions = new BuildOptions();
-            buildOptions.Output = tempFile;
-            buildOptions.TargetDatabaseName = packageName;
+            var deployOptions = new DacDeployOptions();
 
             if (includeCompositeObjects.HasValue)
             {
-                buildOptions.CreateScriptProperty = new[] { $"IncludeCompositeObjects={includeCompositeObjects}" };
+                deployOptions.IncludeCompositeObjects = includeCompositeObjects.Value;
             }
 
             // Act
             packageBuilder.SaveToDisk(tempFile);
-            packageBuilder.GenerateCreateScript(buildOptions);
+            packageBuilder.GenerateCreateScript(tempFile, packageName, deployOptions);
 
             // Assert
             var scriptFilePath = Path.Combine(tempFile.DirectoryName, $"{packageName}_Create.sql");
@@ -652,18 +646,16 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             packageBuilder.SetMetadata(packageName, "1.0.0.0");
             packageBuilder.ValidateModel();
 
-            var buildOptions = new BuildOptions();
-            buildOptions.Output = tempFile;
-            buildOptions.TargetDatabaseName = packageName;
+            var deployOptions = new DacDeployOptions();
 
             if (createNewDatabase.HasValue)
             {
-                buildOptions.CreateScriptProperty = new[] { $"CreateNewDatabase={createNewDatabase}" };
+                deployOptions.CreateNewDatabase = createNewDatabase.Value;
             }
 
             // Act
             packageBuilder.SaveToDisk(tempFile);
-            packageBuilder.GenerateCreateScript(buildOptions);
+            packageBuilder.GenerateCreateScript(tempFile, packageName, deployOptions);
 
             // Assert
             var scriptFilePath = Path.Combine(tempFile.DirectoryName, $"{packageName}_Create.sql");
@@ -695,7 +687,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             packageBuilder.SaveToDisk(tempFile);
 
             // Assert
-            Should.Throw<ArgumentException>(() => packageBuilder.GenerateCreateScript(buildOptions));
+            Should.Throw<ArgumentException>(() => packageBuilder.GenerateCreateScript(tempFile, null, new DacDeployOptions()));
 
             // Cleanup
             tempFile.Delete();

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -571,7 +571,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
 
             // Act
             packageBuilder.SaveToDisk(tempFile);
-            packageBuilder.GenerateCreateScript(tempFile, packageName);
+            packageBuilder.GenerateCreateScript(tempFile, packageName, false);
 
             // Assert
             File.Exists(Path.Combine(tempFile.DirectoryName, $"{packageName}_Create.sql")).ShouldBeTrue();
@@ -635,7 +635,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             packageBuilder.SaveToDisk(tempFile);
 
             // Assert
-            Should.Throw<ArgumentException>(() => packageBuilder.GenerateCreateScript(tempFile, null));
+            Should.Throw<ArgumentException>(() => packageBuilder.GenerateCreateScript(tempFile, null, false));
 
             // Cleanup
             tempFile.Delete();

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -616,7 +616,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
 
             if (includeCompositeObjects.HasValue)
             {
-                buildOptions.Property = new[] { $"IncludeCompositeObjects={includeCompositeObjects}" };
+                buildOptions.CreateScriptProperty = new[] { $"IncludeCompositeObjects={includeCompositeObjects}" };
             }
 
             // Act
@@ -658,7 +658,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
 
             if (createNewDatabase.HasValue)
             {
-                buildOptions.Property = new[] { $"CreateNewDatabase={createNewDatabase}" };
+                buildOptions.CreateScriptProperty = new[] { $"CreateNewDatabase={createNewDatabase}" };
             }
 
             // Act

--- a/test/DacpacTool.Tests/PackageDeployerTests.cs
+++ b/test/DacpacTool.Tests/PackageDeployerTests.cs
@@ -157,10 +157,20 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.SetProperty("AllowDropBlockingAssemblies", "true");
+            packageDeployer.SetDeployProperties(new []{"AllowDropBlockingAssemblies=True"});
 
             // Assert
             packageDeployer.DeployOptions.AllowDropBlockingAssemblies.ShouldBeTrue();
+        }
+
+        [TestMethod]
+        public void SetProperty_SqlCommandVariableValues_ShouldThrowException()
+        {
+            // Arrange
+            var packageDeployer = new PackageDeployer(_console);
+
+            // Assert
+            Should.Throw<ArgumentException>(() => packageDeployer.SetDeployProperty("SqlCommandVariableValues=var1,var2"));
         }
 
         [TestMethod]
@@ -170,7 +180,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            Should.Throw<ArgumentException>(() => packageDeployer.SetProperty("AllowDropBlockingAssemblies", "ARandomString"));
+            Should.Throw<ArgumentException>(() => packageDeployer.SetDeployProperty("AllowDropBlockingAssemblies=ARandomString"));
         }
 
         [TestMethod]
@@ -180,7 +190,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.SetProperty("DoNotDropObjectTypes", "Aggregates,Assemblies");
+            packageDeployer.SetDeployProperty("DoNotDropObjectTypes=Aggregates,Assemblies");
 
             // Assert
             packageDeployer.DeployOptions.DoNotDropObjectTypes.ShouldBe(new ObjectType[] { ObjectType.Aggregates, ObjectType.Assemblies });
@@ -193,7 +203,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.SetProperty("ExcludeObjectTypes", "Contracts,Endpoints");
+            packageDeployer.SetDeployProperty("ExcludeObjectTypes=Contracts,Endpoints");
 
             // Assert
             packageDeployer.DeployOptions.ExcludeObjectTypes.ShouldBe(new ObjectType[] { ObjectType.Contracts, ObjectType.Endpoints });
@@ -206,7 +216,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            packageDeployer.SetProperty("DatabaseSpecification", "Hyperscale,1024,P15");
+            packageDeployer.SetDeployProperty("DatabaseSpecification=Hyperscale,1024,P15");
 
             // Assert
             packageDeployer.DeployOptions.DatabaseSpecification.Edition.ShouldBe(DacAzureEdition.Hyperscale);
@@ -222,7 +232,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packagePath = BuildSimpleModel();
 
             // Act
-            Should.Throw<ArgumentException>(() => packageDeployer.SetProperty("DatabaseSpecification", "MyFancyEdition;1024;P15"));
+            Should.Throw<ArgumentException>(() => packageDeployer.SetDeployProperty("DatabaseSpecification=MyFancyEdition;1024;P15"));
 
             // Assert
             packageDeployer.DeployOptions.DatabaseSpecification.Edition.ShouldBe(DacAzureEdition.Default);
@@ -237,7 +247,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            Should.Throw<ArgumentException>(() => packageDeployer.SetProperty("DatabaseSpecification", "hyperscale;NotAnInteger;P15"));
+            Should.Throw<ArgumentException>(() => packageDeployer.SetDeployProperty("DatabaseSpecification=hyperscale;NotAnInteger;P15"));
 
             // Assert
             packageDeployer.DeployOptions.DatabaseSpecification.Edition.ShouldBe(DacAzureEdition.Default);
@@ -252,7 +262,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             var packageDeployer = new PackageDeployer(_console);
 
             // Act
-            Should.Throw<ArgumentException>(() => packageDeployer.SetProperty("DatabaseSpecification", "hyperscale"));
+            Should.Throw<ArgumentException>(() => packageDeployer.SetDeployProperty("DatabaseSpecification=hyperscale"));
 
             // Assert
             packageDeployer.DeployOptions.DatabaseSpecification.Edition.ShouldBe(DacAzureEdition.Default);

--- a/test/DacpacTool.Tests/PropertyParserTest.cs
+++ b/test/DacpacTool.Tests/PropertyParserTest.cs
@@ -140,7 +140,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         [TestMethod]
         [DataRow("Unknown -> WrongValue", typeof(ArgumentException))]
         [DataRow("=", typeof(ArgumentException))]
-        public void ToDacDeployOptions_WithWronglyFormattedProperty_ShouldThrowException(string property, Type exceptionType)
+        [DataRow("UnknownProperty=212", typeof(ArgumentException))]
+        public void ToDacDeployOptions_WithWronglyFormattedOrhUnknownProperty_ShouldThrowException(string property, Type exceptionType)
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { property } };
@@ -156,8 +157,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         [DataRow(" ")]
         [DataRow(null)]
         [DataRow("")]
-        [DataRow("UnknownProperty=212")]
-        public void ToDacDeployOptions_WithUnknownOrEmptyProperty_ShouldNotThrowException(string property)
+        public void ToDacDeployOptions_WithNullOrEmptyProperty_ShouldNotThrowException(string property)
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { property } };

--- a/test/DacpacTool.Tests/PropertyParserTest.cs
+++ b/test/DacpacTool.Tests/PropertyParserTest.cs
@@ -1,8 +1,4 @@
-﻿// <copyright file="PropertyParserTest.cs" company="Suez">
-// Copyright (c) Suez. All rights reserved.
-// </copyright>
-
-using System;
+﻿using System;
 using Microsoft.SqlServer.Dac;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
@@ -16,7 +12,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithBooleanProperties_ShouldParse()
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[]
+            var buildOptions = new BuildOptions { DeployProperty = new[]
             {
                 "CreateNewDatabase=True",
                 "IgnoreAuthorizer=True"
@@ -34,7 +30,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIntegerProperty_ShouldParse()
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { "CommandTimeout=200" } };
+            var buildOptions = new BuildOptions { DeployProperty = new[] { "CommandTimeout=200" } };
 
             // Act
             var deployOptions = buildOptions.ToDacDeployOptions();
@@ -47,7 +43,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithObjectTypesProperties_ShouldParse()
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[]
+            var buildOptions = new BuildOptions { DeployProperty = new[]
             {
                 $"ExcludeObjectTypes={ObjectType.Audits},{ObjectType.Endpoints},{ObjectType.Queues}",
                 $"DoNotDropObjectTypes={ObjectType.Certificates},{ObjectType.Contracts}"
@@ -73,7 +69,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIncorrectObjectTypesProperty_ShouldThrowException(string property)
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { property } };
+            var buildOptions = new BuildOptions { DeployProperty = new[] { property } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -86,7 +82,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithDacAzureDatabaseSpecificationProperty_ShouldParse()
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { $"DatabaseSpecification={DacAzureEdition.DataWarehouse},20,S3" } };
+            var buildOptions = new BuildOptions { DeployProperty = new[] { $"DatabaseSpecification={DacAzureEdition.DataWarehouse},20,S3" } };
 
             // Act
             var deployOptions = buildOptions.ToDacDeployOptions();
@@ -106,7 +102,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIncorrectDacAzureDatabaseSpecificationProperty_ShouldThrowException(string propertyValue, string exceptionMessage)
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { $"DatabaseSpecification={propertyValue}" } };
+            var buildOptions = new BuildOptions { DeployProperty = new[] { $"DatabaseSpecification={propertyValue}" } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -119,7 +115,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIncorrectIntegerProperty_ShouldThrowException()
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { "CommandTimeout=WrongValue" } };
+            var buildOptions = new BuildOptions { DeployProperty = new[] { "CommandTimeout=WrongValue" } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -132,7 +128,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIncorrectBooleanProperty_ShouldThrowException()
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { "CreateNewDatabase=WrongValue" } };
+            var buildOptions = new BuildOptions { DeployProperty = new[] { "CreateNewDatabase=WrongValue" } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -147,7 +143,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithWronglyFormattedProperty_ShouldThrowException(string property, Type exceptionType)
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { property } };
+            var buildOptions = new BuildOptions { DeployProperty = new[] { property } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -164,7 +160,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithUnknownOrEmptyProperty_ShouldNotThrowException(string property)
         {
             // Arrange
-            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { property } };
+            var buildOptions = new BuildOptions { DeployProperty = new[] { property } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();

--- a/test/DacpacTool.Tests/PropertyParserTest.cs
+++ b/test/DacpacTool.Tests/PropertyParserTest.cs
@@ -9,7 +9,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
     public class PropertyParserTest
     {
         [TestMethod]
-        public void ToDacDeployOptions_WithBooleanProperties_ShouldParse()
+        public void ExtractDeployOptions_WithBooleanProperties_ShouldParse()
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[]
@@ -19,7 +19,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             } };
 
             // Act
-            var deployOptions = buildOptions.ToDacDeployOptions();
+            var deployOptions = buildOptions.ExtractDeployOptions();
 
             // Assert
             deployOptions.CreateNewDatabase.ShouldBeTrue();
@@ -27,20 +27,20 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         }
 
         [TestMethod]
-        public void ToDacDeployOptions_WithIntegerProperty_ShouldParse()
+        public void ExtractDeployOptions_WithIntegerProperty_ShouldParse()
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { "CommandTimeout=200" } };
 
             // Act
-            var deployOptions = buildOptions.ToDacDeployOptions();
+            var deployOptions = buildOptions.ExtractDeployOptions();
 
             // Assert
             deployOptions.CommandTimeout.ShouldBe(200);
         }
 
         [TestMethod]
-        public void ToDacDeployOptions_WithObjectTypesProperties_ShouldParse()
+        public void ExtractDeployOptions_WithObjectTypesProperties_ShouldParse()
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[]
@@ -50,7 +50,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             } };
 
             // Act
-            var deployOptions = buildOptions.ToDacDeployOptions();
+            var deployOptions = buildOptions.ExtractDeployOptions();
 
             // Assert
             deployOptions.ExcludeObjectTypes.Length.ShouldBe(3);
@@ -66,26 +66,26 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         [TestMethod]
         [DataRow("ExcludeObjectTypes=Audits;Endpoints;Queues", DisplayName = "Incorrect separator")]
         [DataRow("ExcludeObjectTypes=P1,P2,P3", DisplayName = "Unknown object types")]
-        public void ToDacDeployOptions_WithIncorrectObjectTypesProperty_ShouldThrowException(string property)
+        public void ExtractDeployOptions_WithIncorrectObjectTypesProperty_ShouldThrowException(string property)
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { property } };
 
             // Act
-            Action action = () => buildOptions.ToDacDeployOptions();
+            Action action = () => buildOptions.ExtractDeployOptions();
 
             // Assert
             action.ShouldThrow<ArgumentException>();
         }
 
         [TestMethod]
-        public void ToDacDeployOptions_WithDacAzureDatabaseSpecificationProperty_ShouldParse()
+        public void ExtractDeployOptions_WithDacAzureDatabaseSpecificationProperty_ShouldParse()
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { $"DatabaseSpecification={DacAzureEdition.DataWarehouse},20,S3" } };
 
             // Act
-            var deployOptions = buildOptions.ToDacDeployOptions();
+            var deployOptions = buildOptions.ExtractDeployOptions();
 
             // Assert
             deployOptions.DatabaseSpecification.ShouldNotBeNull();
@@ -99,39 +99,39 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         [DataRow("DataWarehouse,20", "Expected at least 3 parameters for", DisplayName = "Incorrect number of parameter")]
         [DataRow("AwesomeEdition,20,S2", "Unknown edition", DisplayName = "Unknown database edition")]
         [DataRow("DataWarehouse,X20,S3", "Unable to parse maximum size", DisplayName = "Incorrect database max size")]
-        public void ToDacDeployOptions_WithIncorrectDacAzureDatabaseSpecificationProperty_ShouldThrowException(string propertyValue, string exceptionMessage)
+        public void ExtractDeployOptions_WithIncorrectDacAzureDatabaseSpecificationProperty_ShouldThrowException(string propertyValue, string exceptionMessage)
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { $"DatabaseSpecification={propertyValue}" } };
 
             // Act
-            Action action = () => buildOptions.ToDacDeployOptions();
+            Action action = () => buildOptions.ExtractDeployOptions();
 
             // Assert
             action.ShouldThrow<ArgumentException>().Message.ShouldStartWith(exceptionMessage);
         }
 
         [TestMethod]
-        public void ToDacDeployOptions_WithIncorrectIntegerProperty_ShouldThrowException()
+        public void ExtractDeployOptions_WithIncorrectIntegerProperty_ShouldThrowException()
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { "CommandTimeout=WrongValue" } };
 
             // Act
-            Action action = () => buildOptions.ToDacDeployOptions();
+            Action action = () => buildOptions.ExtractDeployOptions();
 
             // Assert
             action.ShouldThrow<ArgumentException>();
         }
 
         [TestMethod]
-        public void ToDacDeployOptions_WithIncorrectBooleanProperty_ShouldThrowException()
+        public void ExtractDeployOptions_WithIncorrectBooleanProperty_ShouldThrowException()
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { "CreateNewDatabase=WrongValue" } };
 
             // Act
-            Action action = () => buildOptions.ToDacDeployOptions();
+            Action action = () => buildOptions.ExtractDeployOptions();
 
             // Assert
             action.ShouldThrow<FormatException>();
@@ -141,13 +141,13 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         [DataRow("Unknown -> WrongValue", typeof(ArgumentException))]
         [DataRow("=", typeof(ArgumentException))]
         [DataRow("UnknownProperty=212", typeof(ArgumentException))]
-        public void ToDacDeployOptions_WithWronglyFormattedOrhUnknownProperty_ShouldThrowException(string property, Type exceptionType)
+        public void ExtractDeployOptions_WithWronglyFormattedOrhUnknownProperty_ShouldThrowException(string property, Type exceptionType)
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { property } };
 
             // Act
-            Action action = () => buildOptions.ToDacDeployOptions();
+            Action action = () => buildOptions.ExtractDeployOptions();
 
             // Assert
             action.ShouldThrow(exceptionType);
@@ -157,13 +157,13 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         [DataRow(" ")]
         [DataRow(null)]
         [DataRow("")]
-        public void ToDacDeployOptions_WithNullOrEmptyProperty_ShouldNotThrowException(string property)
+        public void ExtractDeployOptions_WithNullOrEmptyProperty_ShouldNotThrowException(string property)
         {
             // Arrange
             var buildOptions = new BuildOptions { DeployProperty = new[] { property } };
 
             // Act
-            Action action = () => buildOptions.ToDacDeployOptions();
+            Action action = () => buildOptions.ExtractDeployOptions();
 
             // Assert
             action.ShouldNotThrow();

--- a/test/DacpacTool.Tests/PropertyParserTest.cs
+++ b/test/DacpacTool.Tests/PropertyParserTest.cs
@@ -1,0 +1,176 @@
+﻿// <copyright file="PropertyParserTest.cs" company="Suez">
+// Copyright (c) Suez. All rights reserved.
+// </copyright>
+
+using System;
+using Microsoft.SqlServer.Dac;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
+{
+    [TestClass]
+    public class PropertyParserTest
+    {
+        [TestMethod]
+        public void ToDacDeployOptions_WithBooleanProperties_ShouldParse()
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[]
+            {
+                "CreateNewDatabase=True",
+                "IgnoreAuthorizer=True"
+            } };
+
+            // Act
+            var deployOptions = buildOptions.ToDacDeployOptions();
+
+            // Assert
+            deployOptions.CreateNewDatabase.ShouldBeTrue();
+            deployOptions.IgnoreAuthorizer.ShouldBeTrue();
+        }
+
+        [TestMethod]
+        public void ToDacDeployOptions_WithIntegerProperty_ShouldParse()
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[] { "CommandTimeout=200" } };
+
+            // Act
+            var deployOptions = buildOptions.ToDacDeployOptions();
+
+            // Assert
+            deployOptions.CommandTimeout.ShouldBe(200);
+        }
+
+        [TestMethod]
+        public void ToDacDeployOptions_WithObjectTypesProperties_ShouldParse()
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[]
+            {
+                $"ExcludeObjectTypes={ObjectType.Audits},{ObjectType.Endpoints},{ObjectType.Queues}",
+                $"DoNotDropObjectTypes={ObjectType.Certificates},{ObjectType.Contracts}"
+            } };
+
+            // Act
+            var deployOptions = buildOptions.ToDacDeployOptions();
+
+            // Assert
+            deployOptions.ExcludeObjectTypes.Length.ShouldBe(3);
+            deployOptions.ExcludeObjectTypes.ShouldContain(ObjectType.Audits);
+            deployOptions.ExcludeObjectTypes.ShouldContain(ObjectType.Endpoints);
+            deployOptions.ExcludeObjectTypes.ShouldContain(ObjectType.Queues);
+
+            deployOptions.DoNotDropObjectTypes.Length.ShouldBe(2);
+            deployOptions.DoNotDropObjectTypes.ShouldContain(ObjectType.Certificates);
+            deployOptions.DoNotDropObjectTypes.ShouldContain(ObjectType.Contracts);
+        }
+
+        [TestMethod]
+        [DataRow("ExcludeObjectTypes=Audits;Endpoints;Queues", DisplayName = "Incorrect separator")]
+        [DataRow("ExcludeObjectTypes=P1,P2,P3", DisplayName = "Unknown object types")]
+        public void ToDacDeployOptions_WithIncorrectObjectTypesProperty_ShouldThrowException(string property)
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[] { property } };
+
+            // Act
+            Action action = () => buildOptions.ToDacDeployOptions();
+
+            // Assert
+            action.ShouldThrow<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ToDacDeployOptions_WithDacAzureDatabaseSpecificationProperty_ShouldParse()
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[] { $"DatabaseSpecification={DacAzureEdition.DataWarehouse},20,S3" } };
+
+            // Act
+            var deployOptions = buildOptions.ToDacDeployOptions();
+
+            // Assert
+            deployOptions.DatabaseSpecification.ShouldNotBeNull();
+            deployOptions.DatabaseSpecification.Edition.ShouldBe(DacAzureEdition.DataWarehouse);
+            deployOptions.DatabaseSpecification.MaximumSize.ShouldBe(20);
+            deployOptions.DatabaseSpecification.ServiceObjective.ShouldBe("S3");
+        }
+
+        [TestMethod]
+        [DataRow("DataWarehouse;20;S3", "Expected database specification to be comma-seperated instead of semi-colon separated", DisplayName = "Incorrect separator")]
+        [DataRow("DataWarehouse,20", "Expected at least 3 parameters for", DisplayName = "Incorrect number of parameter")]
+        [DataRow("AwesomeEdition,20,S2", "Unknown edition", DisplayName = "Unknown database edition")]
+        [DataRow("DataWarehouse,X20,S3", "Unable to parse maximum size", DisplayName = "Incorrect database max size")]
+        public void ToDacDeployOptions_WithIncorrectDacAzureDatabaseSpecificationProperty_ShouldThrowException(string propertyValue, string exceptionMessage)
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[] { $"DatabaseSpecification={propertyValue}" } };
+
+            // Act
+            Action action = () => buildOptions.ToDacDeployOptions();
+
+            // Assert
+            action.ShouldThrow<ArgumentException>().Message.ShouldStartWith(exceptionMessage);
+        }
+
+        [TestMethod]
+        public void ToDacDeployOptions_WithIncorrectIntegerProperty_ShouldThrowException()
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[] { "CommandTimeout=WrongValue" } };
+
+            // Act
+            Action action = () => buildOptions.ToDacDeployOptions();
+
+            // Assert
+            action.ShouldThrow<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ToDacDeployOptions_WithIncorrectBooleanProperty_ShouldThrowException()
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[] { "CreateNewDatabase=WrongValue" } };
+
+            // Act
+            Action action = () => buildOptions.ToDacDeployOptions();
+
+            // Assert
+            action.ShouldThrow<FormatException>();
+        }
+
+        [TestMethod]
+        [DataRow("Unknown -> WrongValue", typeof(ArgumentException))]
+        [DataRow("=", typeof(ArgumentException))]
+        public void ToDacDeployOptions_WithWronglyFormattedProperty_ShouldThrowException(string property, Type exceptionType)
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[] { property } };
+
+            // Act
+            Action action = () => buildOptions.ToDacDeployOptions();
+
+            // Assert
+            action.ShouldThrow(exceptionType);
+        }
+
+        [TestMethod]
+        [DataRow(" ")]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("UnknownProperty=212")]
+        public void ToDacDeployOptions_WithUnknownOrEmptyProperty_ShouldNotThrowException(string property)
+        {
+            // Arrange
+            var buildOptions = new BuildOptions { Property = new[] { property } };
+
+            // Act
+            Action action = () => buildOptions.ToDacDeployOptions();
+
+            // Assert
+            action.ShouldNotThrow();
+        }
+    }
+}

--- a/test/DacpacTool.Tests/PropertyParserTest.cs
+++ b/test/DacpacTool.Tests/PropertyParserTest.cs
@@ -16,7 +16,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithBooleanProperties_ShouldParse()
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[]
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[]
             {
                 "CreateNewDatabase=True",
                 "IgnoreAuthorizer=True"
@@ -34,7 +34,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIntegerProperty_ShouldParse()
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[] { "CommandTimeout=200" } };
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { "CommandTimeout=200" } };
 
             // Act
             var deployOptions = buildOptions.ToDacDeployOptions();
@@ -47,7 +47,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithObjectTypesProperties_ShouldParse()
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[]
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[]
             {
                 $"ExcludeObjectTypes={ObjectType.Audits},{ObjectType.Endpoints},{ObjectType.Queues}",
                 $"DoNotDropObjectTypes={ObjectType.Certificates},{ObjectType.Contracts}"
@@ -73,7 +73,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIncorrectObjectTypesProperty_ShouldThrowException(string property)
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[] { property } };
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { property } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -86,7 +86,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithDacAzureDatabaseSpecificationProperty_ShouldParse()
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[] { $"DatabaseSpecification={DacAzureEdition.DataWarehouse},20,S3" } };
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { $"DatabaseSpecification={DacAzureEdition.DataWarehouse},20,S3" } };
 
             // Act
             var deployOptions = buildOptions.ToDacDeployOptions();
@@ -106,7 +106,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIncorrectDacAzureDatabaseSpecificationProperty_ShouldThrowException(string propertyValue, string exceptionMessage)
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[] { $"DatabaseSpecification={propertyValue}" } };
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { $"DatabaseSpecification={propertyValue}" } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -119,7 +119,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIncorrectIntegerProperty_ShouldThrowException()
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[] { "CommandTimeout=WrongValue" } };
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { "CommandTimeout=WrongValue" } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -132,7 +132,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithIncorrectBooleanProperty_ShouldThrowException()
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[] { "CreateNewDatabase=WrongValue" } };
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { "CreateNewDatabase=WrongValue" } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -147,7 +147,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithWronglyFormattedProperty_ShouldThrowException(string property, Type exceptionType)
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[] { property } };
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { property } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();
@@ -164,7 +164,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         public void ToDacDeployOptions_WithUnknownOrEmptyProperty_ShouldNotThrowException(string property)
         {
             // Arrange
-            var buildOptions = new BuildOptions { Property = new[] { property } };
+            var buildOptions = new BuildOptions { CreateScriptProperty = new[] { property } };
 
             // Act
             Action action = () => buildOptions.ToDacDeployOptions();

--- a/test/DacpacTool.Tests/PropertyParserTest.cs
+++ b/test/DacpacTool.Tests/PropertyParserTest.cs
@@ -134,7 +134,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             Action action = () => buildOptions.ExtractDeployOptions();
 
             // Assert
-            action.ShouldThrow<FormatException>();
+            action.ShouldThrow<ArgumentException>();
         }
 
         [TestMethod]

--- a/test/TestProjectWithGenerateScriptAndTargetDatabaseName/TestProjectWithGenerateScriptAndTargetDatabaseName.csproj
+++ b/test/TestProjectWithGenerateScriptAndTargetDatabaseName/TestProjectWithGenerateScriptAndTargetDatabaseName.csproj
@@ -11,6 +11,8 @@
     <PackageProjectUrl>https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/</PackageProjectUrl>
     <GenerateCreateScript>True</GenerateCreateScript>
     <TargetDatabaseName>MyDatabaseName</TargetDatabaseName>
+    <CreateNewDatabase>True</CreateNewDatabase>
+    <IncludeCompositeObjects>False</IncludeCompositeObjects>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This PR allows setting all the possible properties in the `GenerateCreateScript` functionality. The properties defined in the `csproj` (the `KnownDeployProperties` ones) are now automatically set when generating the create script

Solves issue #230 