### PR TITLE
Code cleanup from temporary enabling .NET analyzers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,16 +26,11 @@ jobs:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         submodules: 'true' # need to check out the SqlTools submodule to build successfully.
 
-    # Install .NET SDK's for 6.0 and 7.0
+    # Install .NET SDK's for 6.0 and 8.0
     - name: Setup dotnet 6.0
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
-
-    - name: Setup dotnet 7.0
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '7.0.x'
 
     - name: Setup dotnet 8.0
       uses: actions/setup-dotnet@v4
@@ -112,7 +107,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-22.04", "macos-13", "windows-2022" ]
-        dotnet: [ '6.0.x', '7.0.x', '8.0.x' ]
+        dotnet: [ '6.0.x', '8.0.x' ]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dotnet new sqlproj -s Sql130
 You should now have a project file with the following contents:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <SqlServerVersion>Sql130</SqlServerVersion>
@@ -94,7 +94,7 @@ If you already have a SSDT (.sqlproj) project in your solution, you can keep tha
 There are a lot of properties that can be set on the model in the resulting `.dacpac` file which can be influenced by setting those properties in the project file using the same name. For example, the snippet below sets the `RecoveryMode` property to `Simple`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <RecoveryMode>Simple</RecoveryMode>
@@ -112,7 +112,7 @@ Like `.sqlproj` projects  `MSBuild.Sdk.SqlProj` supports controlling T-SQL build
 Treating warnings as errors can be optionally enabled by adding a property `TreatTSqlWarningsAsErrors` to the project file:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
         ...
@@ -124,7 +124,7 @@ Treating warnings as errors can be optionally enabled by adding a property `Trea
 To suppress specific warnings from being treated as errors, add a comma-separated list of warning codes to `SuppressTSqlWarnings` property in the project file:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <SuppressTSqlWarnings>71558,71502</SuppressTSqlWarnings>
         <TreatTSqlWarningsAsErrors>True</TreatTSqlWarningsAsErrors>
@@ -136,7 +136,7 @@ To suppress specific warnings from being treated as errors, add a comma-separate
 You can suppress warnings for a specific file by adding `SuppressTSqlWarnings` for this file:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -156,7 +156,7 @@ Support for pre- and post-deployment scripts has been added in version 1.1.0. Th
 To include these scripts into your `.dacpac` add the following to your `.csproj`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -173,7 +173,7 @@ It is important to note that scripts in the `Pre-Deployment` and `Post-Deploymen
 By default the pre- and/or post-deployment script of referenced packages (both [PackageReference](#package-references) and [ProjectReference](#project-references)) are not run when using `dotnet publish`. As of version 1.11.0 this can be optionally enabled by adding a property `RunScriptsFromReferences` to the project file as in the below example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <RunScriptsFromReferences>True</RunScriptsFromReferences>
         ...
@@ -189,7 +189,7 @@ By default the pre- and/or post-deployment script of referenced packages (both [
 Especially when using pre- and post-deployment scripts, but also in other scenario's, it might be useful to define variables that can be controlled at deployment time. This is supported using SQLCMD variables, added in version 1.1.0. These variables can be defined in your project file using the following syntax:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         ...
     </PropertyGroup>
@@ -213,7 +213,7 @@ Especially when using pre- and post-deployment scripts, but also in other scenar
 `MSBuild.Sdk.SqlProj` supports referencing NuGet packages that contain `.dacpac` packages. These can be referenced by using the `PackageReference` format familiar to .NET developers. They can also be installed through the NuGet Package Manager in Visual Studio.
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -227,7 +227,7 @@ Especially when using pre- and post-deployment scripts, but also in other scenar
 It will assume that the `.dacpac` file is inside the `tools` folder of the referenced package and that it has the same name as the NuGet package. Referenced packages that do not adhere to this convention will be silently ignored. However, you have the ability to override this convention by using the `DacpacName` attribute on the `PackageReference` (introduced in version 2.5.0). For example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <SqlServerVersion>Sql160</SqlServerVersion>
@@ -244,7 +244,7 @@ This will add a reference to the `tools\SomeOtherDacpac.dacpac` file inside the 
 By default, the package reference is treated as being part of the same database. For example, if the reference package contains a `.dacpac` that has a table and a stored procedure and you would `dotnet publish` the project the table and stored procedure from that package will be deployed along with the contents of your project to the same database. If this is not desired, you can add the `DatabaseVariableLiteralValue` item metadata to the `PackageReference` specifying a different database name:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -261,7 +261,7 @@ You can also use SQLCMD variables to set references, similar to the behavior of 
 >Note: Don't forget to define appropriate [SQLCMD variables](#sqlcmd-variables)
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -302,7 +302,7 @@ sqlpackage
 Microsoft has recently released NuGet packages containing the definitions of the `master` and `msdb` databases. This is useful if you want to reference objects from those databases within your own projects without getting warnings. To reference these, you'll need to use at least version 2.5.0 of MSBuild.Sdk.SqlProj as you'll need to use the `DacpacName` feature for package references described above. For example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <SqlServerVersion>160</SqlServerVersion>
@@ -322,7 +322,7 @@ For other variants of SQL Server / Azure SQL Database there are dedicated packag
 Similar to package references you can also reference another project by using a `ProjectReference`. These references can be added manually to the project file or they can be added through Visual Studio. For example, consider the following example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -336,7 +336,7 @@ Similar to package references you can also reference another project by using a 
 This will ensure that `MyOtherProject` is built first and the resulting `.dacpac` will be referenced by this project. This means you can use the objects defined in the other project within the scope of this project. If the other project is representing an entirely different database, you can also use `DatabaseVariableLiteralValue` or SQLCMD variables on the `ProjectReference` similar to `PackageReference`:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -370,7 +370,7 @@ In order to solve circular references between databases that may have been incor
 `SuppressMissingDependenciesErrors` to both [Package References](#package-references) and [ProjectReferences](#project-references)):
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
@@ -387,12 +387,12 @@ In order to solve circular references between databases that may have been incor
 
 ## Packaging support
 
-`MSBuild.Sdk.SqlProj` version 2.8.0 and later supports packaging your project into a [NuGet](https://www.nuget.org) package using the `dotnet pack` command.
+`MSBuild.Sdk.SqlProj` version 2.8.1 and later supports packaging your project into a [NuGet](https://www.nuget.org) package using the `dotnet pack` command.
 
 You'll need to set the `PackageProjectUrl` property in the `.csproj` like this:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
   <PropertyGroup>
     ...
     <PackageProjectUrl>your-project-url</PackageProjectUrl>
@@ -464,7 +464,7 @@ To further customize the deployment process, you can use the following propertie
 In addition to these properties, you can also set any of the [documented](https://docs.microsoft.com/dotnet/api/microsoft.sqlserver.dac.dacdeployoptions) deployment options. These are typically set in the project file, for example:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
     <PropertyGroup>
         ...
         <BackupDatabaseBeforeChanges>True</BackupDatabaseBeforeChanges>
@@ -487,7 +487,7 @@ Most of those properties are simple values (like booleans, strings and integers)
 Instead of using `dotnet publish` to deploy changes to a database, you can also have a full SQL script generated that will create the database from scratch and then run that script against a SQL Server. This can be achieved by adding the following to the project file:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
   <PropertyGroup>
       <GenerateCreateScript>True</GenerateCreateScript>
       <IncludeCompositeObjects>True</IncludeCompositeObjects>
@@ -513,7 +513,7 @@ Starting with version 2.7.0 of the SDK, there is support for running static code
 Static code analysis can be enabled by adding the `RunSqlCodeAnalysis` property to the project file:
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
   <PropertyGroup>
     <RunSqlCodeAnalysis>True</RunSqlCodeAnalysis>
     <CodeAnalysisRules>-SqlServer.Rules.SRD0006;-Smells.*</CodeAnalysisRules>
@@ -530,7 +530,7 @@ Any rule violations found during analysis are reported as build warnings.
 Individual rule violations or groups of rules can be configured to be reported as build errors as shown below.
 
 ```xml
-<Project Sdk="MSBuild.Sdk.SqlProj/2.8.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.8.1">
   <PropertyGroup>
     <RunSqlCodeAnalysis>True</RunSqlCodeAnalysis>
     <CodeAnalysisRules>+!SqlServer.Rules.SRN0005;+!SqlServer.Rules.SRD*</CodeAnalysisRules>

--- a/src/DacpacTool/BaseOptions.cs
+++ b/src/DacpacTool/BaseOptions.cs
@@ -1,7 +1,4 @@
-﻿using System.IO;
-using Microsoft.SqlServer.Dac.Model;
-
-namespace MSBuild.Sdk.SqlProj.DacpacTool
+﻿namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
     public abstract class BaseOptions
     {

--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/src/DacpacTool/DatabaseProperty.cs
+++ b/src/DacpacTool/DatabaseProperty.cs
@@ -2,7 +2,7 @@
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    public class DatabaseProperty
+    internal class DatabaseProperty
     {
         private DatabaseProperty(string name, string value)
         {

--- a/src/DacpacTool/DeployOptions.cs
+++ b/src/DacpacTool/DeployOptions.cs
@@ -13,6 +13,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public string[] Property { get; set; }
         public string[] SqlCmdVar { get; set; }
         public bool RunScriptsFromReferences { get; set; }
-        public bool Encrypt { get; set; } = false;
+        public bool Encrypt { get; set; }
     }
 }

--- a/src/DacpacTool/IncludeVariableResolver.cs
+++ b/src/DacpacTool/IncludeVariableResolver.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Collections.Generic;
+﻿using System.Globalization;
 using System.Text;
 using Microsoft.SqlTools.ServiceLayer.BatchParser;
 using Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode;
@@ -26,7 +25,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         public void SetVariable(PositionStruct pos, string name, string value)
         {
-            outputString.AppendFormat("Setting variable {0} to [{1}]\n", name, value);
+            outputString.AppendFormat(CultureInfo.InvariantCulture, "Setting variable {0} to [{1}]\n", name, value);
             batchParserSqlCmd.SetVariable(pos, name, value);
         }
     }

--- a/src/DacpacTool/ModelValidationError.cs
+++ b/src/DacpacTool/ModelValidationError.cs
@@ -21,9 +21,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         public ModelValidationError(DacModelError modelError, string sourceName)
         {
             modelError = modelError ?? throw new ArgumentNullException(nameof(modelError));
-            _sourceName = String.IsNullOrEmpty(sourceName) ? 
+            _sourceName = string.IsNullOrEmpty(sourceName) ? 
                             modelError.SourceName : 
-                            sourceName.Replace("MSSQL::", string.Empty);
+                            sourceName.Replace("MSSQL::", string.Empty, StringComparison.OrdinalIgnoreCase);
             _line = modelError.Line;
             _column = modelError.Column;
             _errorType = modelError.ErrorType;

--- a/src/DacpacTool/PackageAnalyzer.cs
+++ b/src/DacpacTool/PackageAnalyzer.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    internal sealed class PackageAnalyzer
+    public sealed class PackageAnalyzer
     {
         private readonly IConsole _console;
         private readonly HashSet<string> _ignoredRules = new();

--- a/src/DacpacTool/PackageBuilder.cs
+++ b/src/DacpacTool/PackageBuilder.cs
@@ -11,7 +11,7 @@ using Microsoft.SqlServer.Dac.Model;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    internal sealed class PackageBuilder : IDisposable
+    public sealed class PackageBuilder : IDisposable
     {
         private readonly IConsole _console;
         private bool? _modelValid;

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -8,7 +8,7 @@ using Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    internal sealed class PackageDeployer : IBatchEventsHandler
+    public sealed class PackageDeployer : IBatchEventsHandler
     {
         private readonly IConsole _console;
         private string _currentSource;

--- a/src/DacpacTool/PackageDeployer.cs
+++ b/src/DacpacTool/PackageDeployer.cs
@@ -8,7 +8,7 @@ using Microsoft.SqlTools.ServiceLayer.BatchParser.ExecutionEngineCode;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    public sealed class PackageDeployer : IBatchEventsHandler
+    internal sealed class PackageDeployer : IBatchEventsHandler
     {
         private readonly IConsole _console;
         private string _currentSource;
@@ -125,9 +125,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         private void RunDeploymentScriptFromReferences(FileInfo dacpacPackage, string targetDatabaseName, bool isPreDeploy)
         {
             using var model = new TSqlModel(dacpacPackage.FullName, DacSchemaModelStorageType.Memory);
-            var references = model.GetReferencedDacPackages();
+            var references = model.GetReferencedDacPackages().ToList();
 
-            if (!references.Any())
+            if (references.Count == 0)
             {
                 return;
             }

--- a/src/DacpacTool/PropertyParser.cs
+++ b/src/DacpacTool/PropertyParser.cs
@@ -11,7 +11,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
     /// <summary>
     /// Allows to parse properties from build or deploy options
     /// </summary>
-    internal static class PropertyParser
+    public static class PropertyParser
     {
         private static readonly Dictionary<string, Func<string, object>> CustomParsers = new Dictionary<string, Func<string, object>>();
 

--- a/src/DacpacTool/PropertyParser.cs
+++ b/src/DacpacTool/PropertyParser.cs
@@ -11,9 +11,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
     /// <summary>
     /// Allows to parse properties from build or deploy options
     /// </summary>
-    public static class PropertyParser
+    internal static class PropertyParser
     {
-        private static readonly IDictionary<string, Func<string, object>> CustomParsers = new Dictionary<string, Func<string, object>>();
+        private static readonly Dictionary<string, Func<string, object>> CustomParsers = new Dictionary<string, Func<string, object>>();
 
         static PropertyParser()
         {
@@ -42,7 +42,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
         private static PropertyInfo GetDacDeployOptionsProperty(string propertyName)
         {
             var property = typeof(DacDeployOptions).GetProperties()
-                .SingleOrDefault(p => string.Compare(p.Name, propertyName, StringComparison.OrdinalIgnoreCase) == 0);
+                .SingleOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase));
 
             return property;
         }
@@ -106,7 +106,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             foreach (var deployProperty in deployProperties.Where(p => string.IsNullOrWhiteSpace(p) == false))
             {
                 var databaseProperty = DatabaseProperty.Create(deployProperty);
-                var propertyValue =deployOptions.SetDeployProperty(databaseProperty.Name, databaseProperty.Value);
+                var propertyValue = deployOptions.SetDeployProperty(databaseProperty.Name, databaseProperty.Value);
 
                 if (console != null)
                 {
@@ -114,7 +114,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     {
                         ObjectType[] o => string.Join(',', o),
                         DacAzureDatabaseSpecification s => $"{s.Edition},{s.MaximumSize},{s.ServiceObjective}",
-                        _ => propertyValue == null ? "null" : propertyValue.ToString()
+                        _ => propertyValue.ToString()
                     };
 
                     console.WriteLine($"Setting property {databaseProperty.Name} to value {parsedValue}");

--- a/src/DacpacTool/ScriptInspector.cs
+++ b/src/DacpacTool/ScriptInspector.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    internal sealed class ScriptInspector
+    public sealed class ScriptInspector
     {
         private readonly List<string> _includedFiles = new List<string>();
         public IEnumerable<string> IncludedFiles

--- a/src/DacpacTool/ScriptInspector.cs
+++ b/src/DacpacTool/ScriptInspector.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Collections.Generic;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    public sealed class ScriptInspector
+    internal sealed class ScriptInspector
     {
         private readonly List<string> _includedFiles = new List<string>();
         public IEnumerable<string> IncludedFiles
@@ -24,7 +23,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 
         private void AddIncludedFiles(FileInfo file)
         {
-            var parser = new ScriptParser(file.FullName, new IncludeVariableResolver());
+            using var parser = new ScriptParser(file.FullName, new IncludeVariableResolver());
             _includedFiles.AddRange(parser.CollectFileNames());
         }
     }

--- a/src/DacpacTool/ScriptParser.cs
+++ b/src/DacpacTool/ScriptParser.cs
@@ -8,7 +8,7 @@ using Microsoft.SqlServer.Dac.Model;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    internal sealed class ScriptParser : ICommandHandler, IDisposable
+    public sealed class ScriptParser : ICommandHandler, IDisposable
     {
         private readonly Parser _parser;
         private bool _parsed;

--- a/src/DacpacTool/ScriptParser.cs
+++ b/src/DacpacTool/ScriptParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -8,7 +8,7 @@ using Microsoft.SqlServer.Dac.Model;
 
 namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
-    public class ScriptParser : ICommandHandler
+    internal sealed class ScriptParser : ICommandHandler, IDisposable
     {
         private readonly Parser _parser;
         private bool _parsed;
@@ -95,6 +95,11 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             Console.Error.WriteLine(error.ToString());
 
             return action == OnErrorAction.Ignore ? BatchParserAction.Continue : BatchParserAction.Abort;
+        }
+
+        public void Dispose()
+        {
+            _parser?.Dispose();
         }
     }
 }

--- a/src/DacpacTool/SqlRuleProblemExtensions.cs
+++ b/src/DacpacTool/SqlRuleProblemExtensions.cs
@@ -9,7 +9,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
     /// <summary>
     /// A wrapper for <see cref="SqlRuleProblem" /> that provides MSBuild compatible output and source document information.
     /// </summary>
-    public static class SqlRuleProblemExtensions
+    internal static class SqlRuleProblemExtensions
     {
         public static string GetOutputMessage(this SqlRuleProblem sqlRuleProblem, HashSet<string> errorRules)
         {
@@ -23,8 +23,8 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             }
 
             var wildCardErrorRules = errorRules
-                .Where(r => r.EndsWith("*", StringComparison.OrdinalIgnoreCase));
-            if (wildCardErrorRules.Any(s => sqlRuleProblem.RuleId.StartsWith(s[..^1])))
+                .Where(r => r.EndsWith('*'));
+            if (wildCardErrorRules.Any(s => sqlRuleProblem.RuleId.StartsWith(s[..^1], StringComparison.OrdinalIgnoreCase)))
             {
                 sqlRuleProblemSeverity = SqlRuleProblemSeverity.Error;
             }

--- a/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj
+++ b/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj
@@ -1,4 +1,4 @@
-
+﻿
 <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
 
   <PropertyGroup>
@@ -31,7 +31,7 @@
 
   <Target Name="IncludeDacpacTool" AfterTargets="Build">
     <PropertyGroup>
-      <_DacpacToolSupportedTfms>net6.0;net7.0;net8.0</_DacpacToolSupportedTfms>
+      <_DacpacToolSupportedTfms>net6.0;net8.0</_DacpacToolSupportedTfms>
     </PropertyGroup>
     <ItemGroup>
       <DacpacToolSupportedTfms Include="$(_DacpacToolSupportedTfms)" />

--- a/test/DacpacTool.Tests/DacpacTool.Tests.csproj
+++ b/test/DacpacTool.Tests/DacpacTool.Tests.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>MSBuild.Sdk.SqlProj.DacpacTool.Tests</AssemblyName>
     <RootNamespace>MSBuild.Sdk.SqlProj.DacpacTool.Tests</RootNamespace>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Also: removed .NET 7 support and updated readme to 2.8.1

```xml
<AnalysisMode>all</AnalysisMode>
    <EnableNETAnalyzers>true</EnableNETAnalyzers>
    <AnalysisLevel>latest</AnalysisLevel>
    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
```