### PR TITLE
Update sqltoolsservice

### DIFF
--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -31,6 +31,7 @@
     <None Include="$(ManagedBatchParserPath)/Localization/sr.strings" Link="BatchParser/%(Filename)%(Extension)" />
     <Compile Include="$(ManagedBatchParserPath)/BatchParser/**/*.cs" Link="BatchParser/%(Filename)%(Extension)" />
     <Compile Include="$(ManagedBatchParserPath)/ReliableConnection/**/*.cs" Link="BatchParser/%(Filename)%(Extension)" />
+    <Compile Include="$(ManagedBatchParserPath)/Utility/**/*" Link="BatchParser/%(Filename)%(Extension)" /> 
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This updates the sqltoolsservice submodule to the latest version. I don't think we can easily get rid of this dependency, but at least now it is up-to-date again against the latest commit there. Hopefully this will pass CI as well.

Signed-off-by: Jonathan Mezach <jonathan.mezach@rr-wfm.com>