### PR TITLE
SqlCmdVariable DefaultValue should not be written to .dacpac as per docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Especially when using pre- and post-deployment scripts, but also in other scenar
 </Project>
 ```
 
-> Note: The value of `Value` is checked first and if it found to be empty, we'll fall back to `DefaultValue`.
+> Note: With version 3.0.0 of the SDK, the `DefaultValue` is not applied to the build output, in line with the standard `.sqlproj` behaviour.
 
 ## Package references
 `MSBuild.Sdk.SqlProj` supports referencing NuGet packages that contain `.dacpac` packages. These can be referenced by using the `PackageReference` format familiar to .NET developers. They can also be installed through the NuGet Package Manager in Visual Studio.

--- a/src/DacpacTool/Extensions.cs
+++ b/src/DacpacTool/Extensions.cs
@@ -260,18 +260,11 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
             {
                 var varWithValue = variable.Split('=', 2);
                 var variableName = varWithValue[0];
-                string variableDefaultValue = string.Empty;
 
-                if (varWithValue.Length > 1 && !string.IsNullOrEmpty(varWithValue[1]))
-                {
-                    variableDefaultValue = varWithValue[1];
-                    Console.WriteLine($"Adding SqlCmd variable {variableName} with default value {variableDefaultValue}");
-                }
-                else
-                    Console.WriteLine($"Adding SqlCmd variable {variableName}");
+                Console.WriteLine($"Adding SqlCmd variable {variableName}");
 
                 var setMetadataMethod = customData.GetType().GetMethod("SetMetadata", BindingFlags.Public | BindingFlags.Instance);
-                setMetadataMethod.Invoke(customData, new object[] { variableName, variableDefaultValue });
+                setMetadataMethod.Invoke(customData, new object[] { variableName, string.Empty });
             }
 
             AddCustomData(dataSchemaModel, customData);

--- a/test/DacpacTool.Tests/DacpacTool.Tests.csproj
+++ b/test/DacpacTool.Tests/DacpacTool.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>MSBuild.Sdk.SqlProj.DacpacTool.Tests</AssemblyName>
     <RootNamespace>MSBuild.Sdk.SqlProj.DacpacTool.Tests</RootNamespace>
     <LangVersion>9.0</LangVersion>
+    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DacpacTool.Tests/PackageBuilderTests.cs
+++ b/test/DacpacTool.Tests/PackageBuilderTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.SqlServer.Dac;
 using Microsoft.SqlServer.Dac.Model;
+using Microsoft.SqlServer.Management.HadrModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
 
@@ -264,7 +265,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
                     && d.Type == "SqlCmdVariable")
                 .SelectMany(d => d.Items)
                 .Where(i => i.Name == "DbReader"
-                    && i.Value == "dbReaderValue")
+                    && i.Value == string.Empty)
                 .ToList().Count.ShouldBe(1);
 
             headerParser.GetCustomData()
@@ -272,7 +273,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
                     && d.Type == "SqlCmdVariable")
                 .SelectMany(d => d.Items)
                 .Where(i => i.Name == "DbWriter"
-                    && i.Value == "dbWriterValue")
+                    && i.Value == string.Empty)
                 .ToList().Count.ShouldBe(1);
 
             // Cleanup


### PR DESCRIPTION
https://learn.microsoft.com/sql/tools/sql-database-projects/concepts/sqlcmd-variables

fixes #448