### PR TITLE
Even if AnalysisSucceded, there could be errors from analysis. 

### DIFF
--- a/MSBuild.Sdk.SqlProj.sln
+++ b/MSBuild.Sdk.SqlProj.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29806.167
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35707.178 d17.12
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B0420F9B-A902-4E9D-8B29-55B4F626483B}"
 EndProject
@@ -10,6 +10,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D25C8812-D92E-41D5-9BC9-30AFCF45063B}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.github\workflows\main.yml = .github\workflows\main.yml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DacpacTool", "src\DacpacTool\DacpacTool.csproj", "{78CA944A-928F-48FA-B29F-C5DC96E67684}"

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ You should now have a project file with the following contents:
     <ItemGroup>
         <!-- These packages adds additional code analysis rules -->
         <!-- We recommend using these, but they can be removed if desired -->
-        <PackageReference Include="ErikEJ.DacFX.SqlServer.Rules" Version="1.2.0">
+        <PackageReference Include="ErikEJ.DacFX.SqlServer.Rules" Version="1.2.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="ErikEJ.DacFX.TSQLSmellSCA" Version="1.2.0">
+        <PackageReference Include="ErikEJ.DacFX.TSQLSmellSCA" Version="1.2.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -615,11 +615,11 @@ We know of the following public rules NuGet packages, that you can add to your p
 
 ```xml
     <ItemGroup>
-        <PackageReference Include="ErikEJ.DacFX.SqlServer.Rules" Version="1.2.0">
+        <PackageReference Include="ErikEJ.DacFX.SqlServer.Rules" Version="1.2.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="ErikEJ.DacFX.TSQLSmellSCA" Version="1.2.0">
+        <PackageReference Include="ErikEJ.DacFX.TSQLSmellSCA" Version="1.2.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/DacpacTool/PackageAnalyzer.cs
+++ b/src/DacpacTool/PackageAnalyzer.cs
@@ -80,13 +80,16 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 }
 
                 var result = service.Analyze(model);
+
+                var errors = result.GetAllErrors();
+                foreach (var err in errors)
+                {
+                    _console.WriteLine(err.GetOutputMessage());
+                }
+
                 if (!result.AnalysisSucceeded)
                 {
-                    var errors = result.GetAllErrors();
-                    foreach (var err in errors)
-                    {
-                        _console.WriteLine(err.GetOutputMessage());
-                    }
+                    _console.WriteLine($"Analysis of package '{outputFile}' failed");
                     return;
                 }
                 else

--- a/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/sqlproj.csproj
+++ b/src/MSBuild.Sdk.SqlProj.Templates/templates/sqlproj/sqlproj.csproj
@@ -9,11 +9,11 @@
     <ItemGroup>
         <!-- These packages adds additional code analysis rules -->
         <!-- We recommend using these, but they can be removed if desired -->
-        <PackageReference Include="ErikEJ.DacFX.SqlServer.Rules" Version="1.2.0">
+        <PackageReference Include="ErikEJ.DacFX.SqlServer.Rules" Version="1.2.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="ErikEJ.DacFX.TSQLSmellSCA" Version="1.2.0">
+        <PackageReference Include="ErikEJ.DacFX.TSQLSmellSCA" Version="1.2.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
This was discovered during a debugging session with the AdventureWorks schema.

Changed the implementation to always report any errors.

Updated SqlServer.Rules: This analyzer was previously split into two .dll files, and this was not handled well in multiple scenarios

Updated TSqlSmellsSCA: Fixed NRE triggered by Computed columns in AdventureWorks schema

fixes #707